### PR TITLE
Backward compatibility for a couple attributes.

### DIFF
--- a/gxformat2/export.py
+++ b/gxformat2/export.py
@@ -24,6 +24,8 @@ def from_galaxy_native(native_workflow_dict, tool_interface=None, json_wrapper=F
     data = OrderedDict()
     data['class'] = 'GalaxyWorkflow'
     _copy_common_properties(native_workflow_dict, data)
+    if "name" in native_workflow_dict:
+        data["label"] = native_workflow_dict.pop("name")
     for top_level_key in ['tags', 'uuid', 'report']:
         value = native_workflow_dict.get(top_level_key)
         if value:
@@ -169,9 +171,12 @@ def _convert_input_connections(from_native_step, to_format2_step, label_map):
 def _convert_post_job_actions(from_native_step, to_format2_step):
 
     def _ensure_output_def(key):
-        if "outputs" not in to_format2_step:
-            to_format2_step["outputs"] = {}
-        outputs_dict = to_format2_step["outputs"]
+        if "outputs" in to_format2_step:
+            to_format2_step["out"] = to_format2_step.pop("outputs")
+        elif "out" not in to_format2_step:
+            to_format2_step["out"] = {}
+
+        outputs_dict = to_format2_step["out"]
         if key not in outputs_dict:
             outputs_dict[key] = {}
         return outputs_dict[key]

--- a/gxformat2/schema/v19_09.py
+++ b/gxformat2/schema/v19_09.py
@@ -2602,7 +2602,19 @@ to connect the output value to downstream parameters.
 
 class GalaxyWorkflow(Process):
     """
-This is documentation for a workflow!
+A Galaxy workflow description. This record corresponds to the description of a workflow that should be executable
+on a Galaxy server that includes the contained tool definitions.
+
+The workflows API or the user interface of Galaxy instances that are of version 19.09 or newer should be able to
+import a document defining this record.
+
+## A note about `label` field.
+
+This is the name of the workflow in the Galaxy user interface. This is the mechanism that
+users will primarily identify the workflow using. Legacy support - this may also be called 'name' and Galaxy will
+consume the workflow document fine and treat this attribute correctly - however in order to validate against this
+workflow definition schema the attribute should be called `label`.
+
     """
     def __init__(
         self,
@@ -2757,7 +2769,7 @@ This is documentation for a workflow!
                 else:
                     _errors__.append(
                         ValidationException(
-                            "invalid field `%s`, expected one of: `id`, `label`, `doc`, `inputs`, `outputs`, `name`, `class`, `steps`, `report`" % (k),
+                            "invalid field `%s`, expected one of: `id`, `label`, `doc`, `inputs`, `outputs`, `class`, `steps`, `report`" % (k),
                             SourceLine(_doc, k, str)
                         )
                     )
@@ -2780,7 +2792,7 @@ This is documentation for a workflow!
         if self.id is not None:
             u = save_relative_uri(
                 self.id,
-                self.name,
+                base_url,
                 True,
                 None,
                 relative_uris)
@@ -2791,42 +2803,42 @@ This is documentation for a workflow!
             r['label'] = save(
                 self.label,
                 top=False,
-                base_url=self.name,
+                base_url=self.id,
                 relative_uris=relative_uris)
 
         if self.doc is not None:
             r['doc'] = save(
                 self.doc,
                 top=False,
-                base_url=self.name,
+                base_url=self.id,
                 relative_uris=relative_uris)
 
         if self.inputs is not None:
             r['inputs'] = save(
                 self.inputs,
                 top=False,
-                base_url=self.name,
+                base_url=self.id,
                 relative_uris=relative_uris)
 
         if self.outputs is not None:
             r['outputs'] = save(
                 self.outputs,
                 top=False,
-                base_url=self.name,
+                base_url=self.id,
                 relative_uris=relative_uris)
 
         if self.steps is not None:
             r['steps'] = save(
                 self.steps,
                 top=False,
-                base_url=self.name,
+                base_url=self.id,
                 relative_uris=relative_uris)
 
         if self.report is not None:
             r['report'] = save(
                 self.report,
                 top=False,
-                base_url=self.name,
+                base_url=self.id,
                 relative_uris=relative_uris)
 
         if top and self.loadingOptions.namespaces:
@@ -2834,7 +2846,7 @@ This is documentation for a workflow!
 
         return r
 
-    attrs = frozenset(['id', 'label', 'doc', 'inputs', 'outputs', 'name', 'class', 'steps', 'report'])
+    attrs = frozenset(['id', 'label', 'doc', 'inputs', 'outputs', 'class', 'steps', 'report'])
 
 
 _vocab = {

--- a/java/src/main/java/org/galaxyproject/gxformat2/v19_09/GalaxyWorkflow.java
+++ b/java/src/main/java/org/galaxyproject/gxformat2/v19_09/GalaxyWorkflow.java
@@ -8,7 +8,19 @@ import org.galaxyproject.gxformat2.v19_09.utils.Savable;
  *
  * <BLOCKQUOTE>
  *
- * This is documentation for a workflow!
+ * A Galaxy workflow description. This record corresponds to the description of a workflow that
+ * should be executable on a Galaxy server that includes the contained tool definitions.
+ *
+ * <p>The workflows API or the user interface of Galaxy instances that are of version 19.09 or newer
+ * should be able to import a document defining this record.
+ *
+ * <p>## A note about `label` field.
+ *
+ * <p>This is the name of the workflow in the Galaxy user interface. This is the mechanism that
+ * users will primarily identify the workflow using. Legacy support - this may also be called 'name'
+ * and Galaxy will consume the workflow document fine and treat this attribute correctly - however
+ * in order to validate against this workflow definition schema the attribute should be called
+ * `label`.
  *
  * </BLOCKQUOTE>
  */

--- a/java/src/main/java/org/galaxyproject/gxformat2/v19_09/GalaxyWorkflowImpl.java
+++ b/java/src/main/java/org/galaxyproject/gxformat2/v19_09/GalaxyWorkflowImpl.java
@@ -12,7 +12,19 @@ import org.galaxyproject.gxformat2.v19_09.utils.ValidationException;
  *
  * <BLOCKQUOTE>
  *
- * This is documentation for a workflow!
+ * A Galaxy workflow description. This record corresponds to the description of a workflow that
+ * should be executable on a Galaxy server that includes the contained tool definitions.
+ *
+ * <p>The workflows API or the user interface of Galaxy instances that are of version 19.09 or newer
+ * should be able to import a document defining this record.
+ *
+ * <p>## A note about `label` field.
+ *
+ * <p>This is the name of the workflow in the Galaxy user interface. This is the mechanism that
+ * users will primarily identify the workflow using. Legacy support - this may also be called 'name'
+ * and Galaxy will consume the workflow document fine and treat this attribute correctly - however
+ * in order to validate against this workflow definition schema the attribute should be called
+ * `label`.
  *
  * </BLOCKQUOTE>
  */

--- a/schema/v19_09/workflow.yml
+++ b/schema/v19_09/workflow.yml
@@ -264,13 +264,29 @@ $graph:
     - specializeFrom: cwl:OutputParameter
       specializeTo: WorkflowOutputParameter
   documentRoot: true
-  doc: This is documentation for a workflow!
+  doc: |
+    A Galaxy workflow description. This record corresponds to the description of a workflow that should be executable
+    on a Galaxy server that includes the contained tool definitions.
+
+    The workflows API or the user interface of Galaxy instances that are of version 19.09 or newer should be able to
+    import a document defining this record.
+
+    ## A note about `label` field.
+
+    This is the name of the workflow in the Galaxy user interface. This is the mechanism that
+    users will primarily identify the workflow using. Legacy support - this may also be called 'name' and Galaxy will
+    consume the workflow document fine and treat this attribute correctly - however in order to validate against this
+    workflow definition schema the attribute should be called `label`.
   fields:
-    - name: name
-      type: string?
-      jsonldPredicate: "@id"  #  will this bite me?
-      doc: |
-        The name of the workflow.
+    # I can't find a way to override the documentation of label, even though I contextual.
+    # - name: label
+    #  type:
+    #    - "null"
+    #    - string
+    #  jsonldPredicate: "rdfs:label"
+    #  doc: {$include: ../common/workflow_label_description.txt}
+    #  # Legacy support - this may also be called 'name' and Galaxy will consume the workflow fine and treat this
+    #  # attribute correctly - however in order to validate against this schema the attribute should be called label.
     - name: "class"
       jsonldPredicate:
         "_id": "@type"

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -2,6 +2,7 @@ import copy
 import os
 
 from gxformat2.converter import python_to_workflow, yaml_to_workflow
+from gxformat2.export import from_galaxy_native
 from gxformat2.interface import ImporterGalaxyInterface
 
 TEST_PATH = os.path.abspath(os.path.dirname(__file__))
@@ -44,3 +45,13 @@ def native_workflow_outputs(native_as_dict):
     for step in steps.values():
         for workflow_output in step.get("workflow_outputs", []):
             yield workflow_output
+
+
+def round_trip(has_yaml):
+    as_native = to_native(has_yaml)
+    assert_valid_native(as_native)
+    return from_native(as_native)
+
+
+def from_native(native_as_dict):
+    return from_galaxy_native(native_as_dict, None)

--- a/tests/test_backward_compatiblitiy.py
+++ b/tests/test_backward_compatiblitiy.py
@@ -1,0 +1,44 @@
+"""Test converting to native format and back out migrates legacy syntax elements."""
+
+from ._helpers import round_trip
+
+LEGACY_PJA_1 = """
+class: GalaxyWorkflow
+name: My Cool Workflow!
+inputs:
+  input1: data
+outputs:
+  out1:
+    outputSource: second_cat/out_file1
+steps:
+  first_cat:
+    tool_id: cat1
+    in:
+      input1: input1
+    outputs:
+       out_file1:
+         hide: true
+         rename: "the new value"
+  second_cat:
+    tool_id: cat1
+    in:
+      input1: first_cat/out_file1
+"""
+
+
+def test_workflow_name():
+    """To be valid schema salad syntax, workflow name should be label."""
+    updated = round_trip(LEGACY_PJA_1)
+    assert "label" in updated
+    assert updated["label"] == "My Cool Workflow!"
+    assert "name" not in updated
+
+
+def test_step_outputs():
+    """To be valid a valid Process - workflow steps should have an out element, not outputs.
+
+    This is also much more consistent with 'in' syntax.
+    """
+    updated = round_trip(LEGACY_PJA_1)
+    assert "out" in updated["steps"]["first_cat"]
+    assert "outputs" not in updated["steps"]["first_cat"]

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -6,7 +6,9 @@ from gxformat2.export import from_galaxy_native
 from ._helpers import (
     assert_valid_native,
     copy_without_workflow_output_labels,
+    from_native,
     native_workflow_outputs,
+    round_trip,
     TEST_PATH,
     to_native,
 )
@@ -236,16 +238,6 @@ def test_export_native_no_labels():
 
     assert after_step_count == before_step_count
     assert after_output_count == before_output_count, round_trip_unicycler
-
-
-def round_trip(has_yaml):
-    as_native = to_native(has_yaml)
-    assert_valid_native(as_native)
-    return from_native(as_native)
-
-
-def from_native(native_as_dict):
-    return from_galaxy_native(native_as_dict, None)
 
 
 def assert_valid_format2(as_dict_format2):

--- a/tests/test_post_job_action_import.py
+++ b/tests/test_post_job_action_import.py
@@ -83,5 +83,5 @@ def test_post_job_action_to_native(wf_template):
         assert expected_pja == converted_pjas, "Expected:\n%s\nActual:\n%s'" % (expected_pja, converted_pjas)
         assert_valid_native(native)
         roundtrip_workflow = from_native(native)
-        out_def = roundtrip_workflow['steps']['cat']['outputs']['out_file1']
+        out_def = roundtrip_workflow['steps']['cat']['out']['out_file1']
         assert action_key in out_def, "%s not in %s" % (action_key, out_def)


### PR DESCRIPTION
I made some small tweaks when writing schema to make the schema a valid schema salad schema. Add a test case to ensure that these attributes are handled either in their new or old version, but also that round tripping the document from native and back yields the newer form that validates.

GalaxyWorkflow.name -> GalaxyWorkflow.label because name is not a valid record field in schema salad sadly and because we're inheriting 'label' from Process anyway.

WorkflowStep.outputs -> Workflow.out - can't overlap with 'outputs' defined at the workflow level but this is more inline with 'in' and CWL's Process definition as well.