### PR TITLE
Enable CWL abstract export.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 # Optional dependencies
 schema-salad
+cwltool
 
 # For testing
 tox

--- a/gxformat2/abstract.py
+++ b/gxformat2/abstract.py
@@ -1,0 +1,179 @@
+"""Module for exporting Galaxy workflows to CWL abstract interface."""
+import argparse
+import sys
+
+from gxformat2._scripts import ensure_format2
+from gxformat2._yaml import ordered_dump, ordered_load
+from gxformat2.converter import steps_as_list
+from gxformat2.normalize import ensure_implicit_step_outs, walk_id_list_or_dict
+
+CWL_VERSION = "v1.2.0-dev5"
+
+SCRIPT_DESCRIPTION = """
+This script converts the an executable Galaxy workflow (in either format -
+Format 2 or native .ga) into an abstract CWL representation.
+
+In order to represent Galaxy tool executions in the Common Workflow Language
+workflow language, they are serialized as v1.2+ abstract 'Operation' classes.
+Because abstract 'Operation' classes are used, the resulting CWL workflow is
+not executable - either in Galaxy or by CWL implementations. The resulting CWL
+file should be thought of more as a common metadata specification describing
+the workflow structure.
+"""
+
+
+def from_dict(workflow_dict, subworkflow=False):
+    """Convert dictified Galaxy workflow into abstract CWL representation."""
+    # TODO: pass some sort of flag to ensure_format2 to make sure information
+    # about step outputs that may be present in native format is not lost when
+    # converting to Format2.
+    workflow_dict = ensure_format2(workflow_dict)
+    ensure_implicit_step_outs(workflow_dict)
+
+    requirements = {}
+    abstract_dict = {
+        'class': 'Workflow',
+    }
+    if not subworkflow:
+        abstract_dict["cwlVersion"] = CWL_VERSION
+    # inputs and outputs already mostly in CWL format...
+    abstract_dict["inputs"] = _format2_inputs_to_abstract(workflow_dict.get("inputs", {}))
+    abstract_dict["outputs"] = _format2_outputs_to_abstract(workflow_dict.get("outputs", {}))
+    steps = {}
+    for format2_step in steps_as_list(workflow_dict):
+        steps[format2_step["label"]] = _format2_step_to_abstract(format2_step, requirements=requirements)
+
+    abstract_dict["steps"] = steps
+    if requirements:
+        abstract_dict['requirements'] = requirements
+    return abstract_dict
+
+
+def _format2_step_to_abstract(format2_step, requirements):
+    """Convert Format2 step CWL 1.2+ abstract operation."""
+    abstract_step = {}
+    if "run" in format2_step:
+        # probably encountered in subworkflow.
+        format2_run = format2_step["run"]
+        format2_run_class = format2_run["class"]
+        requirements["SubworkflowFeatureRequirement"] = {}
+        if format2_run_class == "GalaxyWorkflow":
+            # preprocess to ensure it has outs - should the original call be recursive?
+            ensure_implicit_step_outs(format2_run)
+            step_run = from_dict(format2_run, subworkflow=True)
+            abstract_step["run"] = step_run
+        else:
+            raise NotImplementedError("Unknown runnabled type encountered [%s]" % format2_run_class)
+    else:
+        step_run = {
+            "class": "Operation",
+            "doc": format2_step.get("doc", ""),
+            "inputs": {},  # TODO
+            "outputs": {},  # TODO
+        }
+        abstract_step["run"] = step_run
+    abstract_step["in"] = _format2_in_to_abstract(format2_step.get("in", []))
+    abstract_step["out"] = _format2_out_to_abstract(format2_step.get("out", []))
+    return abstract_step
+
+
+def _format2_in_to_abstract(in_dict):
+    """Convert Format2 'in' dict for step into CWL abstract 'in' dict."""
+    return in_dict
+
+
+def _format2_out_to_abstract(out):
+    """Convert Format2 'out' list for step into CWL abstract 'out' list."""
+    cwl_out = []
+    if isinstance(out, dict):
+        for out_name, out_def in out.items():
+            # discard PJA info when converting to abstract CWL
+            cwl_out.append(out_name)
+    else:
+        cwl_out = out
+    return cwl_out
+
+
+def _format2_inputs_to_abstract(inputs):
+    """Strip Galaxy extensions or namespace them."""
+    abstract_inputs = {}
+
+    for input_name, input_def in walk_id_list_or_dict(inputs):
+        if isinstance(input_def, dict):
+            input_type = input_def.get("type")
+        else:
+            input_type = input_def
+            input_def = {"type": input_type}
+
+        if input_type == "data":
+            input_def["type"] = "File"
+
+        _format2_type_to_abstract(input_def)
+
+        # Strip off Galaxy extensions
+        input_def.pop("position", None)
+        abstract_inputs[input_name] = input_def
+
+    return abstract_inputs
+
+
+def _format2_type_to_abstract(has_type):
+    format2_type = has_type.pop("type")
+    if format2_type == "data":
+        cwl_type = "File"
+    elif format2_type == "collection":
+        # TODO: handled nested collections, pairs, etc...
+        cwl_type = "File[]"
+    else:
+        cwl_type = format2_type
+    optional = has_type.pop("optional", False)
+    if optional:
+        cwl_type += "?"
+    has_type["type"] = cwl_type
+
+
+def _format2_outputs_to_abstract(outputs):
+    """Strip Galaxy extensions or namespace them."""
+    for output_name, output in walk_id_list_or_dict(outputs):
+        if "type" not in output:
+            output["type"] = "File"
+    return outputs
+
+
+def main(argv=None):
+    """Entry point for script to export abstract interface."""
+    if argv is None:
+        argv = sys.argv[1:]
+
+    args = _parser().parse_args(argv)
+
+    workflow_path = args.input_path
+    output_path = args.output_path or (workflow_path + ".abstract.cwl")
+
+    if workflow_path == "-":
+        workflow_dict = ordered_load(sys.stdin)
+    else:
+        with open(workflow_path, "r") as f:
+            workflow_dict = ordered_load(f)
+
+    abstract_dict = from_dict(workflow_dict)
+    with open(output_path, "w") as f:
+        ordered_dump(abstract_dict, f)
+
+    return 0
+
+
+def _parser():
+    parser = argparse.ArgumentParser(description=SCRIPT_DESCRIPTION)
+    parser.add_argument('input_path', metavar='INPUT', type=str,
+                        help='input workflow path (.ga/gxwf.yml)')
+    parser.add_argument('output_path', metavar='OUTPUT', type=str, nargs="?",
+                        help='input workflow path (.cwl)')
+    return parser
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+
+__all__ = ('main', 'from_dict')

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ ENTRY_POINTS = '''
      [console_scripts]
      gxwf-lint=gxformat2.lint:main
      gxwf-viz=gxformat2.cytoscape:main
+     gxwf-abstract-export=gxformat2.abstract:main
 '''
 PACKAGE_DATA = {
     # Be sure to update MANIFEST.in for source dist.

--- a/tests/example_wfs.py
+++ b/tests/example_wfs.py
@@ -1,0 +1,170 @@
+"""Example workflows used by testing infrastructure."""
+
+BASIC_WORKFLOW = """
+class: GalaxyWorkflow
+doc: |
+  Simple workflow that no-op cats a file and then selects 10 random lines.
+inputs:
+  the_input:
+    type: File
+    doc: input doc
+outputs:
+  the_output:
+    outputSource: cat/out_file1
+steps:
+  cat:
+    tool_id: cat1
+    doc: cat doc
+    in:
+      input1: the_input
+"""
+
+WORKFLOW_WITH_REPEAT = """
+class: GalaxyWorkflow
+inputs:
+  input1: data
+outputs:
+  out1:
+    outputSource: first_cat/out_file1
+steps:
+  first_cat:
+    tool_id: cat
+    in:
+      input1: input1
+      queries_0|input2: input1
+      queries_1|input2: input1
+"""
+
+NESTED_WORKFLOW = """
+class: GalaxyWorkflow
+inputs:
+  outer_input: data
+outputs:
+  outer_output:
+    outputSource: second_cat/out_file1
+steps:
+  first_cat:
+    tool_id: cat1
+    in:
+      input1: outer_input
+  nested_workflow:
+    run:
+      class: GalaxyWorkflow
+      inputs:
+        inner_input: data
+      outputs:
+        workflow_output:
+          outputSource: random_lines/out_file1
+      steps:
+        random_lines:
+          tool_id: random_lines1
+          state:
+            num_lines: 2
+            input:
+              $link: inner_input
+            seed_source:
+              seed_source_selector: set_seed
+              seed: asdf
+    in:
+      inner_input: first_cat/out_file1
+  split:
+    tool_id: split
+    in:
+      input1: nested_workflow/workflow_output
+  second_cat:
+    tool_id: cat_list
+    in:
+      input1: split/output
+"""
+
+RULES_TOOL = """
+class: GalaxyWorkflow
+inputs:
+  input_c: collection
+outputs:
+  out1:
+    outputSource: random_lines/out_file1
+steps:
+  apply:
+    tool_id: __APPLY_RULES__
+    state:
+      input:
+        $link: input_c
+      rules:
+        rules:
+          - type: add_column_metadata
+            value: identifier0
+          - type: add_column_metadata
+            value: identifier0
+        mapping:
+          - type: list_identifiers
+            columns: [0, 1]
+  random_lines:
+    tool_id: random_lines1
+    state:
+      num_lines: 1
+      input:
+        $link: apply/output
+      seed_source:
+        seed_source_selector: set_seed
+        seed: asdf
+"""
+
+RUNTIME_INPUTS = """
+class: GalaxyWorkflow
+inputs:
+  input1: data
+outputs:
+  out1:
+    outputSource: random/out_file1
+steps:
+  the_pause:
+    type: pause
+    in:
+      input: input1
+  random:
+    tool_id: random_lines1
+    runtime_inputs:
+      - num_lines
+    state:
+      input:
+        $link: the_pause
+      seed_source:
+        seed_source_selector: set_seed
+        seed: asdf
+"""
+
+PJA_1 = """
+class: GalaxyWorkflow
+inputs:
+  input1: data
+outputs:
+  out1:
+    outputSource: second_cat/out_file1
+steps:
+  first_cat:
+    tool_id: cat1
+    in:
+      input1: input1
+    out:
+       out_file1:
+         hide: true
+         rename: "the new value"
+  second_cat:
+    tool_id: cat1
+    in:
+      input1: first_cat/out_file1
+"""
+
+OPTIONAL_INPUT = """
+class: GalaxyWorkflow
+inputs:
+  the_input:
+    type: File
+    optional: true
+steps:
+  cat:
+    tool_id: cat_optional
+    in:
+      input1: the_input
+"""

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -12,6 +12,7 @@ from ._helpers import (
     TEST_PATH,
     to_native,
 )
+from .example_wfs import OPTIONAL_INPUT
 
 
 def test_import_export():
@@ -274,18 +275,7 @@ def test_export_native_no_labels():
 
 
 def test_optional_inputs():
-    as_dict = round_trip("""
-class: GalaxyWorkflow
-inputs:
-  the_input:
-    type: File
-    optional: true
-steps:
-  cat:
-    tool_id: cat_optional
-    in:
-      input1: the_input
-""")
+    as_dict = round_trip(OPTIONAL_INPUT)
     print(as_dict["inputs"])
     assert as_dict["inputs"]["the_input"]["optional"]
 

--- a/tests/test_export_abstract.py
+++ b/tests/test_export_abstract.py
@@ -1,0 +1,103 @@
+"""Test exporting Galaxy workflow to abstract CWL syntax."""
+from cwltool.context import (
+    getdefault,
+    LoadingContext,
+)
+from cwltool.main import (
+    default_loader,
+    fetch_document,
+    resolve_and_validate_document,
+    tool_resolver,
+)
+
+from gxformat2._yaml import ordered_dump, ordered_load
+from gxformat2.abstract import CWL_VERSION, from_dict
+from .example_wfs import (
+    BASIC_WORKFLOW,
+    NESTED_WORKFLOW,
+    OPTIONAL_INPUT,
+    PJA_1,
+    RULES_TOOL,
+    RUNTIME_INPUTS,
+    WORKFLOW_WITH_REPEAT,
+)
+from .test_normalize import _both_formats
+
+# double converting nested workflow doesn't work right, bug in gxformat2
+# unrelated to abstract I think.
+EXAMPLES = [
+    BASIC_WORKFLOW,
+    # NESTED_WORKFLOW,
+    OPTIONAL_INPUT,
+    PJA_1,
+    RULES_TOOL,
+    RUNTIME_INPUTS,
+    WORKFLOW_WITH_REPEAT,
+]
+
+# TODO:
+# - Ensure when reading native format - output information is included,
+#   not needed for concise format2 but would make the CWL more authentic
+# - Fix bug in converted nested workflow that results in the following tests
+#   breaking.
+# - Write test around RUNTIME_INPUTs - translate it to string input.
+# - Write test and handle $links embedded in Format2 workflows
+
+
+def test_abstract_export():
+    for example in EXAMPLES:
+        for as_dict in _both_formats(example):
+            _run_example(as_dict)
+
+
+def test_to_cwl_optional():
+    for as_dict in _both_formats(OPTIONAL_INPUT):
+        abstract_as_dict = from_dict(as_dict)
+        assert abstract_as_dict["inputs"]["the_input"]["type"] == "File?"
+
+
+def test_to_cwl_array():
+    for as_dict in _both_formats(RULES_TOOL):
+        abstract_as_dict = from_dict(as_dict)
+        assert abstract_as_dict["inputs"]["input_c"]["type"] == "File[]"
+
+
+def test_nested_workflow():
+    _run_example(ordered_load(NESTED_WORKFLOW))
+
+
+def _run_example(as_dict):
+    abstract_as_dict = from_dict(as_dict)
+    with open("test.cwl", "w") as f:
+        ordered_dump(abstract_as_dict, f)
+
+    check_abstract_def(abstract_as_dict)
+
+    # validate format2 workflows
+    enable_dev = "dev" in CWL_VERSION
+    loadingContext = LoadingContext()
+    loadingContext.enable_dev = enable_dev
+    loadingContext.loader = default_loader(
+        loadingContext.fetcher_constructor,
+        enable_dev=enable_dev,
+    )
+    loadingContext.resolver = getdefault(loadingContext.resolver, tool_resolver)
+    loadingContext, workflowobj, uri = fetch_document("./test.cwl", loadingContext)
+    loadingContext, uri = resolve_and_validate_document(
+        loadingContext,
+        workflowobj,
+        uri,
+    )
+
+
+def check_abstract_def(abstract_as_dict):
+    assert abstract_as_dict["class"] == "Workflow"
+    assert abstract_as_dict["cwlVersion"] == CWL_VERSION
+    for step_id, step_def in abstract_as_dict["steps"].items():
+        assert "run" in step_def
+        run = step_def["run"]
+        assert "in" in step_def
+        assert isinstance(step_def["in"], (dict, list))
+        assert run["class"] in ["Operation", "Workflow"]
+        assert "out" in step_def
+        assert isinstance(step_def["out"], list)

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -11,169 +11,18 @@ from ._helpers import (
     TEST_PATH,
     to_native,
 )
+from .example_wfs import (
+    BASIC_WORKFLOW,
+    NESTED_WORKFLOW,
+    PJA_1,
+    RULES_TOOL,
+    RUNTIME_INPUTS,
+    WORKFLOW_WITH_REPEAT,
+)
 
 _deep_copy = copy.deepcopy
 
 TEST_LINT_EXAMPLES = os.path.join(TEST_INTEROP_EXAMPLES, "lint")
-
-BASIC_WORKFLOW = """
-class: GalaxyWorkflow
-doc: |
-  Simple workflow that no-op cats a file and then selects 10 random lines.
-inputs:
-  the_input:
-    type: File
-    doc: input doc
-outputs:
-  the_output:
-    outputSource: cat/out_file1
-steps:
-  cat:
-    tool_id: cat1
-    doc: cat doc
-    in:
-      input1: the_input
-"""
-
-WORKFLOW_WITH_REPEAT = """
-class: GalaxyWorkflow
-inputs:
-  input1: data
-outputs:
-  out1:
-    outputSource: first_cat/out_file1
-steps:
-  first_cat:
-    tool_id: cat
-    in:
-      input1: input1
-      queries_0|input2: input1
-      queries_1|input2: input1
-"""
-
-
-RULES_TOOL = """
-class: GalaxyWorkflow
-inputs:
-  input_c: collection
-outputs:
-  out1:
-    outputSource: random_lines/out_file1
-steps:
-  apply:
-    tool_id: __APPLY_RULES__
-    state:
-      input:
-        $link: input_c
-      rules:
-        rules:
-          - type: add_column_metadata
-            value: identifier0
-          - type: add_column_metadata
-            value: identifier0
-        mapping:
-          - type: list_identifiers
-            columns: [0, 1]
-  random_lines:
-    tool_id: random_lines1
-    state:
-      num_lines: 1
-      input:
-        $link: apply/output
-      seed_source:
-        seed_source_selector: set_seed
-        seed: asdf
-"""
-
-
-NESTED_WORKFLOW = """
-class: GalaxyWorkflow
-inputs:
-  outer_input: data
-outputs:
-  outer_output:
-    outputSource: second_cat/out_file1
-steps:
-  first_cat:
-    tool_id: cat1
-    in:
-      input1: outer_input
-  nested_workflow:
-    run:
-      class: GalaxyWorkflow
-      inputs:
-        inner_input: data
-      outputs:
-        workflow_output:
-          outputSource: random_lines/out_file1
-      steps:
-        random_lines:
-          tool_id: random_lines1
-          state:
-            num_lines: 2
-            input:
-              $link: inner_input
-            seed_source:
-              seed_source_selector: set_seed
-              seed: asdf
-    in:
-      inner_input: first_cat/out_file1
-  split:
-    tool_id: split
-    in:
-      input1: nested_workflow/workflow_output
-  second_cat:
-    tool_id: cat_list
-    in:
-      input1: split/output
-"""
-
-
-RUNTIME_INPUTS = """
-class: GalaxyWorkflow
-inputs:
-  input1: data
-outputs:
-  out1:
-    outputSource: random/out_file1
-steps:
-  the_pause:
-    type: pause
-    in:
-      input: input1
-  random:
-    tool_id: random_lines1
-    runtime_inputs:
-      - num_lines
-    state:
-      input:
-        $link: the_pause
-      seed_source:
-        seed_source_selector: set_seed
-        seed: asdf
-"""
-
-PJA_1 = """
-class: GalaxyWorkflow
-inputs:
-  input1: data
-outputs:
-  out1:
-    outputSource: second_cat/out_file1
-steps:
-  first_cat:
-    tool_id: cat1
-    in:
-      input1: input1
-    out:
-       out_file1:
-         hide: true
-         rename: "the new value"
-  second_cat:
-    tool_id: cat1
-    in:
-      input1: first_cat/out_file1
-"""
 
 WITH_REPORT = """
 class: GalaxyWorkflow


### PR DESCRIPTION
- Python library functionality and script setup in setup.py - ``gxwf-abstract-export [input] [output]``
- Write tests for a variety of workflows, for each:
  - Try exporting both from Format 2 and native (.ga) formats.
  - Validate the output is valid ``v1.2.0-dev5`` abstract CWL with the latest cwltool.
- Write test for collection inputs (these get translated to ``File[]`` inputs).
- Write test for optional inputs (these get translated with ``?`` appended to the CWL type).
- Write test for dealing with subworkflows as nested CWL workflows.
