### PR TITLE
Produce newly released v1.2 CWL in gxwf-abstract-export.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,8 @@
 # Optional dependencies
 schema-salad
-cwltool
+# Needs to validate v1.2
+cwltool>=3.0.20200807132242
+
 
 mypy
 

--- a/gxformat2/abstract.py
+++ b/gxformat2/abstract.py
@@ -8,7 +8,7 @@ from gxformat2.converter import steps_as_list
 from gxformat2.normalize import NormalizedWorkflow, walk_id_list_or_dict
 from gxformat2.yaml import ordered_dump_to_path, ordered_load
 
-CWL_VERSION = "v1.2.0-dev5"
+CWL_VERSION = "v1.2"
 
 SCRIPT_DESCRIPTION = """
 This script converts the an executable Galaxy workflow (in either format -


### PR DESCRIPTION
Stop generating dev version CWL.