### PR TITLE
test_abstract_export: use tmpdir

### DIFF
--- a/tests/test_export_abstract.py
+++ b/tests/test_export_abstract.py
@@ -31,18 +31,18 @@ from .test_normalize import _both_formats
 
 # double converting nested workflow doesn't work right, bug in gxformat2
 # unrelated to abstract I think.
-EXAMPLES = [
-    BASIC_WORKFLOW,
-    FLOAT_INPUT_DEFAULT,
-    INT_INPUT,
-    # NESTED_WORKFLOW,
-    OPTIONAL_INPUT,
-    PJA_1,
-    RULES_TOOL,
-    RUNTIME_INPUTS,
-    STRING_INPUT,
-    WORKFLOW_WITH_REPEAT,
-]
+EXAMPLES = {
+    "BASIC_WORKFLOW": BASIC_WORKFLOW,
+    "FLOAT_INPUT_DEFAULT": FLOAT_INPUT_DEFAULT,
+    "INT_INPUT": INT_INPUT,
+    # "NESTED_WORKFLOW": NESTED_WORKFLOW,
+    "OPTIONAL_INPUT": OPTIONAL_INPUT,
+    "PJA_1": PJA_1,
+    "RULES_TOOL": RULES_TOOL,
+    "RUNTIME_INPUTS": RUNTIME_INPUTS,
+    "STRING_INPUT": STRING_INPUT,
+    "WORKFLOW_WITH_REPEAT": WORKFLOW_WITH_REPEAT,
+}
 
 # TODO:
 # - Ensure when reading native format - output information is included,
@@ -53,10 +53,11 @@ EXAMPLES = [
 # - Write test and handle $links embedded in Format2 workflows
 
 
-def test_abstract_export():
-    for example in EXAMPLES:
-        for as_dict in _both_formats(example):
-            _run_example(as_dict)
+def test_abstract_export(tmpdir):
+    for name, example in EXAMPLES.items():
+        format2, native = _both_formats(example)
+        _run_example(format2, os.path.join(tmpdir, "%s_from_format2.cwl" % name))
+        _run_example(native, os.path.join(tmpdir, "%s_from_native.cwl" % name))
 
 
 def test_to_cwl_optional():


### PR DESCRIPTION
Changes `test_abstract_export` to use the `tmpdir` pytest fixture and to write separate files for the different examples. This allows for easy post-run checks on the various outputs:

```
$ ls /tmp/pytest-of-simleo/pytest-current/test_abstract_exportcurrent
BASIC_WORKFLOW_from_format2.cwl       PJA_1_from_native.cwl
BASIC_WORKFLOW_from_native.cwl        RULES_TOOL_from_format2.cwl
FLOAT_INPUT_DEFAULT_from_format2.cwl  RULES_TOOL_from_native.cwl
FLOAT_INPUT_DEFAULT_from_native.cwl   RUNTIME_INPUTS_from_format2.cwl
INT_INPUT_from_format2.cwl            RUNTIME_INPUTS_from_native.cwl
INT_INPUT_from_native.cwl             STRING_INPUT_from_format2.cwl
OPTIONAL_INPUT_from_format2.cwl       STRING_INPUT_from_native.cwl
OPTIONAL_INPUT_from_native.cwl        WORKFLOW_WITH_REPEAT_from_format2.cwl
PJA_1_from_format2.cwl                WORKFLOW_WITH_REPEAT_from_native.cwl
```

Whereas with the current setup, a `test.cwl` is created and overwritten in the current dir.