### PR TITLE
Drop support for Python 3.5, add 3.9

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,5 +1,5 @@
 name: Python CI
-on: [push]
+on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -7,17 +7,17 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: ['3.6', '3.7', '3.8', '3.9']
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools
         pip install tox tox-gh-actions
     - name: Test with tox
       run: tox

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -102,7 +102,7 @@ Before you submit a pull request, check that it meets these guidelines:
 
 1. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring.
-2. The pull request should work for Python >=3.5. Check CI results on pull
+2. The pull request should work for Python >=3.6. Check CI results on pull
    request and make sure that the tests pass for all supported Python versions.
 
 Tox_

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Default tests run with make test and make quick-tests
 NOSE_TESTS?=tests gxformat2
 # Default environment for make tox
-ENV?=py27
+ENV?=py36
 # Extra arguments supplied to tox command
 ARGS?=
 # Location of virtualenv used for development.
@@ -57,7 +57,7 @@ flake8: ## check style using flake8 for current Python (faster than lint)
 	$(IN_VENV) flake8 --max-complexity 11 $(SOURCE_DIR)  $(TEST_DIR)
 
 lint: ## check style using tox and flake8 for Python 2 and Python 3
-	$(IN_VENV) tox -e py27-lint && tox -e py35-lint
+	$(IN_VENV) tox -e py36-lint && tox -e py39-lint
 
 lint-readme: ## check README formatting for PyPI
 	$(IN_VENV) python setup.py check -r -s
@@ -69,7 +69,7 @@ lint-docs: ready-docs
 test: ## run tests with the default Python (faster than tox)
 	$(IN_VENV) nosetests $(NOSE_TESTS)
 
-tox: ## run tests with tox in the specified ENV, defaults to py27
+tox: ## run tests with tox in the specified ENV
 	$(IN_VENV) tox -e $(ENV) -- $(ARGS)
 
 coverage: ## check code coverage quickly with the default Python

--- a/setup.py
+++ b/setup.py
@@ -94,10 +94,10 @@ setup(
         'Topic :: Software Development :: Testing',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     test_suite=TEST_DIR,
     tests_require=test_requirements

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,15 @@
 # TODO: implement doc linting
 [tox]
-envlist = py{35,36,37,38}-lint, py35-lintdocstrings, py35-lintreadme, py{35,36,37,38}-mypy, py{35,36,37,38}-unit
+envlist = py{36,37,38,39}-lint, py36-lintdocstrings, py36-lintreadme, py{36,37,38,39}-mypy, py{36,37,38,39}-unit
 source_dir = gxformat2
 test_dir = tests
 
 [gh-actions]
 python =
-    3.5: py35-unit, py35-lint, py35-lintdocstrings, py35-mypy, py35-lintdocs
-    3.6: py36-unit, py36-mypy
+    3.6: py36-unit, py36-mypy, py36-lint, py36-lintdocs, py36-lintdocstrings
     3.7: py37-unit, py37-mypy
-    3.8: py38-unit, py38-lint, py38-mypy, py38-lintdocs
+    3.8: py38-unit, py38-mypy
+    3.9: py39-unit, py39-mypy, py39-lint, py39-lintdocs
 
 [testenv]
 commands =


### PR DESCRIPTION
Run tox CI workflow also on pull requests.

Work done as part of the ELIXIR-UK Hackathon 2021.