### PR TITLE
Convert Format2 workflow `label` to native `name`

### DIFF
--- a/gxformat2/abstract.py
+++ b/gxformat2/abstract.py
@@ -36,6 +36,10 @@ def from_dict(workflow_dict: dict, subworkflow=False):
     abstract_dict = {
         'class': 'Workflow',
     }  # type: Dict[str, Any]
+    for attr in ('doc', 'label'):
+        value = workflow_dict.get(attr)
+        if value:
+            abstract_dict[attr] = value
     if not subworkflow:
         abstract_dict["cwlVersion"] = CWL_VERSION
     # inputs and outputs already mostly in CWL format...
@@ -94,7 +98,7 @@ def _format2_out_to_abstract(format2_step, run=None):
     if "out" in format2_step:
         out = format2_step.get("out")
         if isinstance(out, dict):
-            for out_name, out_def in out.items():
+            for out_name in out.keys():
                 # discard PJA info when converting to abstract CWL
                 cwl_out.append(out_name)
         else:
@@ -143,7 +147,7 @@ def _format2_type_to_abstract(has_type):
 
 def _format2_outputs_to_abstract(outputs):
     """Strip Galaxy extensions or namespace them."""
-    for output_name, output in walk_id_list_or_dict(outputs):
+    for _output_name, output in walk_id_list_or_dict(outputs):
         if "type" not in output:
             output["type"] = "File"
     return outputs

--- a/gxformat2/converter.py
+++ b/gxformat2/converter.py
@@ -184,7 +184,7 @@ def _python_to_workflow(as_python, conversion_context):
     _ensure_defaults(as_python, {
         "a_galaxy_workflow": "true",
         "format-version": "0.1",
-        "name": "Workflow",
+        "name": as_python.pop("label", "Workflow"),
         "uuid": str(uuid.uuid4()),
     })
     _populate_annotation(as_python)
@@ -618,7 +618,7 @@ class SubworkflowConversionContext(BaseConversionContext):
         return self.parent_context.get_subworkflow_conversion_context_graph(graph_id)
 
 
-def _action(type, name, arguments={}):
+def _action(type, name, arguments):
     return {
         "action_arguments": arguments,
         "action_type": type,

--- a/tests/example_wfs.py
+++ b/tests/example_wfs.py
@@ -2,6 +2,7 @@
 
 BASIC_WORKFLOW = """
 class: GalaxyWorkflow
+label: Simple workflow
 doc: |
   Simple workflow that no-op cats a file and then selects 10 random lines.
 inputs:

--- a/tests/test_export_abstract.py
+++ b/tests/test_export_abstract.py
@@ -107,7 +107,9 @@ def _run_example_path(path):
         return _run_example(ordered_load(f), out)
 
 
-def _run_example(as_dict, out="test.cwl"):
+def _run_example(as_dict, out=None):
+    if not out:
+        out = _examples_path_for("test.cwl")
     abstract_as_dict = from_dict(as_dict)
     with open(out, "w") as f:
         ordered_dump(abstract_as_dict, f)

--- a/tests/test_export_abstract.py
+++ b/tests/test_export_abstract.py
@@ -59,6 +59,13 @@ def test_abstract_export():
             _run_example(as_dict)
 
 
+def test_basic_workflow():
+    for as_dict in _both_formats(BASIC_WORKFLOW):
+        abstract_as_dict = from_dict(as_dict)
+        assert abstract_as_dict["label"] == "Simple workflow"
+        assert abstract_as_dict["doc"] == "Simple workflow that no-op cats a file and then selects 10 random lines.\n"
+
+
 def test_to_cwl_optional():
     for as_dict in _both_formats(OPTIONAL_INPUT):
         abstract_as_dict = from_dict(as_dict)
@@ -137,7 +144,7 @@ def _run_example(as_dict, out=None):
 def check_abstract_def(abstract_as_dict):
     assert abstract_as_dict["class"] == "Workflow"
     assert abstract_as_dict["cwlVersion"] == CWL_VERSION
-    for step_id, step_def in abstract_as_dict["steps"].items():
+    for step_def in abstract_as_dict["steps"].values():
         assert "run" in step_def
         run = step_def["run"]
         assert "in" in step_def

--- a/tests/test_to_native.py
+++ b/tests/test_to_native.py
@@ -8,10 +8,23 @@ from gxformat2.lint import lint_ga_path
 from gxformat2.linting import LintContext
 from ._helpers import TEST_PATH, to_example_path
 from .example_wfs import (
+    BASIC_WORKFLOW,
     INT_INPUT,
 )
 
 EXAMPLES_DIR_NAME = "native"
+
+
+def test_basic_workflow():
+    format2_path = to_example_path("basic", EXAMPLES_DIR_NAME, "gxwf.yml")
+    with open(format2_path, "w") as f:
+        f.write(BASIC_WORKFLOW)
+    out = _run_example_path(format2_path)
+    with open(out, "r") as f:
+        as_native = json.load(f)
+    assert as_native["name"] == "Simple workflow"
+    assert as_native["annotation"] == "Simple workflow that no-op cats a file and then selects 10 random lines.\n"
+    assert as_native.get("label") is None
 
 
 def test_double_convert_sars_wf():


### PR DESCRIPTION
Also: copy `label` and `doc` attributes when converting a Format2 workflow to abstract CWL.

Reduce the gap with https://github.com/workflowhub-eu/galaxy2cwl .

The "Don't create untracked file during unit tests" commit is a quick alternative to https://github.com/galaxyproject/gxformat2/pull/50 .

Work done as part of the ELIXIR-UK Hackathon 2021.