### PR TITLE
Propagate `doc` field to abstract CWL format

### DIFF
--- a/gxformat2/abstract.py
+++ b/gxformat2/abstract.py
@@ -63,6 +63,10 @@ def from_dict(workflow_dict: dict, subworkflow=False):
 def _format2_step_to_abstract(format2_step, requirements):
     """Convert Format2 step CWL 1.2+ abstract operation."""
     abstract_step = {}
+    for attr in ('doc', ):
+        value = format2_step.get(attr)
+        if value:
+            abstract_step[attr] = value
     if "run" in format2_step:
         # probably encountered in subworkflow.
         format2_run = format2_step["run"]

--- a/tests/test_export_abstract.py
+++ b/tests/test_export_abstract.py
@@ -146,7 +146,10 @@ def _run_example(as_dict, out=None):
 def check_abstract_def(abstract_as_dict):
     assert abstract_as_dict["class"] == "Workflow"
     assert abstract_as_dict["cwlVersion"] == CWL_VERSION
-    for step_def in abstract_as_dict["steps"].values():
+    steps = abstract_as_dict["steps"]
+    if isinstance(steps, dict):
+        steps = steps.values()
+    for step_def in steps:
         assert "run" in step_def
         run = step_def["run"]
         assert "in" in step_def

--- a/tests/test_export_abstract.py
+++ b/tests/test_export_abstract.py
@@ -65,6 +65,7 @@ def test_basic_workflow():
         abstract_as_dict = from_dict(as_dict)
         assert abstract_as_dict["label"] == "Simple workflow"
         assert abstract_as_dict["doc"] == "Simple workflow that no-op cats a file and then selects 10 random lines.\n"
+        assert abstract_as_dict["steps"]["cat"]["doc"] == "cat doc"
 
 
 def test_to_cwl_optional():


### PR DESCRIPTION
Also:
- Handle abstract CWL steps as list in tests