### PR TITLE
Add support for when: source

### DIFF
--- a/gxformat2/converter.py
+++ b/gxformat2/converter.py
@@ -697,8 +697,9 @@ def _populate_input_connections(context, step, connect):
                     source = {"id": step_id, "output_name": output_name}
                     if is_subworkflow_step:
                         subworkflow_conversion_context = context.get_subworkflow_conversion_context(step)
-                        input_subworkflow_step_id = subworkflow_conversion_context.step_id(key)
-                        source["input_subworkflow_step_id"] = input_subworkflow_step_id
+                        if key in subworkflow_conversion_context.labels:
+                            input_subworkflow_step_id = subworkflow_conversion_context.step_id(key)
+                            source["input_subworkflow_step_id"] = input_subworkflow_step_id
                     input_connection_value.append(source)
         if key == "$step":
             key = "__NO_INPUT_OUTPUT_NAME__"

--- a/gxformat2/converter.py
+++ b/gxformat2/converter.py
@@ -413,6 +413,10 @@ def transform_tool(context, step):
         "post_job_actions": {},
         "tool_version": None,
     })
+    if "when" in step and "source" in step["when"]:
+        step_id, output_name = context.step_output(step["when"]["source"])
+        step["when"]["source"] = {"id": step_id, "output_name": output_name}
+
     post_job_actions = step["post_job_actions"]
     _populate_annotation(step)
 

--- a/gxformat2/converter.py
+++ b/gxformat2/converter.py
@@ -388,6 +388,10 @@ def transform_pause(context, step, default_name="Pause for dataset review"):
 
 
 def transform_subworkflow(context, step):
+    if "when" in step and "source" in step["when"]:
+        step_id, output_name = context.step_output(step["when"]["source"])
+        step["when"]["source"] = {"id": step_id, "output_name": output_name}
+
     _populate_annotation(step)
 
     _ensure_inputs_connections(step)


### PR DESCRIPTION
The idea is to skip steps if a source boolean parameter value specified in `when: source: step/output` is `false` (prior to really implementing expressions in the GUI and evaluation on the backend / as a tool-ish alternative). Experimenting with this for now, but maybe we can go with a regular hard-coded expression instead (`return $job.when_source` ?) ... we need to provide the possibility to let workflow authors provide "non-consumed" (as in not mapped to a tool / subworkflow parameter) step inputs for CWL anyway.