### PR TITLE
Add now mandatory readthedocs config files

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,28 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats:
+  - pdf
+  - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - path: .
+    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinx-rtd-theme

--- a/tox.ini
+++ b/tox.ini
@@ -24,12 +24,13 @@ deps =
     lint: flake8-import-order
     lint: flake8-bugbear
     lint,lintdocstrings: flake8
+    lintdocs: -rdocs/requirements.txt
     lintdocstrings: flake8_docstrings
     mypy: mypy
     mypy: types-PyYAML
     mypy: types-requests
-    unit,lintdocs: -rrequirements.txt
-    unit,lintdocs: -rdev-requirements.txt
+    unit: -rrequirements.txt
+    unit: -rdev-requirements.txt
     lintreadme: readme
 skip_install =
     lint,lintdocstrings,lintreadme: True


### PR DESCRIPTION
Docs builds currently fail with:

```
Problem in your project's configuration. No default configuration file found at repository's root.
```

See e.g. https://readthedocs.org/projects/gxformat2/builds/22459724/