### PR TITLE
Support URL and TRS URL references in subworkflow run: fields

### DIFF
--- a/gxformat2/converter.py
+++ b/gxformat2/converter.py
@@ -262,8 +262,12 @@ def run_workflow_to_step(conversion_context, step, run_action):
         )
 
 
+def _is_url(value):
+    return isinstance(value, str) and value.startswith(("http://", "https://", "base64://"))
+
+
 def _is_graph_id_reference(run_action):
-    return run_action and not isinstance(run_action, dict)
+    return run_action and not isinstance(run_action, dict) and not _is_url(run_action)
 
 
 def transform_data_input(context, step):
@@ -475,7 +479,10 @@ class BaseConversionContext:
         return self.subworkflow_conversion_contexts[step_id]
 
     def get_runnable_description(self, run_action):
-        if "@import" in run_action:
+        if _is_url(run_action):
+            return run_action
+
+        if isinstance(run_action, dict) and "@import" in run_action:
             if len(run_action) > 1:
                 raise Exception("@import must be only key if present.")
 

--- a/gxformat2/export.py
+++ b/gxformat2/export.py
@@ -115,9 +115,14 @@ def from_galaxy_native(native_workflow_dict, tool_interface=None, json_wrapper=F
             _copy_properties(step, step_dict, optional_props=optional_props)
             _convert_input_connections(step, step_dict, label_map)
             _convert_post_job_actions(step, step_dict)
-            subworkflow_native_dict = step["subworkflow"]
-            subworkflow = from_galaxy_native(subworkflow_native_dict, tool_interface=tool_interface, json_wrapper=False, compact=compact)
-            step_dict["run"] = subworkflow
+            content_source = step.get("content_source")
+            content_id = step.get("content_id")
+            if content_source in ("url", "trs_url") and content_id:
+                step_dict["run"] = content_id
+            else:
+                subworkflow_native_dict = step["subworkflow"]
+                subworkflow = from_galaxy_native(subworkflow_native_dict, tool_interface=tool_interface, json_wrapper=False, compact=compact)
+                step_dict["run"] = subworkflow
             steps.append(step_dict)
 
         elif module_type == 'tool':

--- a/tests/example_wfs.py
+++ b/tests/example_wfs.py
@@ -364,3 +364,33 @@ inputs:
     type: [string]
 steps: []
 """
+
+URL_SUBWORKFLOW = """
+class: GalaxyWorkflow
+inputs:
+  outer_input: data
+steps:
+  first_cat:
+    tool_id: cat1
+    in:
+      input1: outer_input
+  nested_workflow:
+    run: https://example.com/my_subworkflow.gxwf.yml
+    in:
+      inner_input: first_cat/out_file1
+"""
+
+TRS_URL_SUBWORKFLOW = """
+class: GalaxyWorkflow
+inputs:
+  outer_input: data
+steps:
+  first_cat:
+    tool_id: cat1
+    in:
+      input1: outer_input
+  nested_workflow:
+    run: https://dockstore.org/api/ga4gh/trs/v2/tools/%23workflow%2Fgithub.com%2Fexample/versions/main/PLAIN-GALAXY/descriptor
+    in:
+      inner_input: first_cat/out_file1
+"""


### PR DESCRIPTION
Enable format2 workflows to reference external subworkflows by URL in the run: field (e.g., run: https://example.com/workflow.gxwf.yml) instead of requiring inline subworkflow definitions.

Export (native → format2): Handle content_source/content_id on subworkflow steps directly, emitting run: <url> instead of requiring the Galaxy-side placeholder hack that injects dummy subworkflow dicts for conversion then patches URLs back afterward.

Import (format2 → native): URL strings in run: fields pass through as content_id on the native step dict, letting Galaxy resolve the actual workflow content from the URL at import time. Graph ID detection updated to not misinterpret URLs as $graph references.