### PR TITLE
Add to-native and to-format2 commands to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,8 @@ Checkout their help for more information.
     $ gxwf-lint --help
     $ gxwf-viz --help
     $ gxwf-abstract-export --help
+    $ gxwf-to-native --help
+    $ gxwf-to-format2 --help
 
 This library and associated scripts are licensed under the MIT License.
 


### PR DESCRIPTION
While handy commands, `gxwf-to-native` and `gxwf-to-format2` were missing from the README :slightly_smiling_face:  