### PR TITLE
Fix URI generation on Windows when linting

### DIFF
--- a/gxformat2/lint.py
+++ b/gxformat2/lint.py
@@ -3,6 +3,7 @@
 import argparse
 import os
 import sys
+from pathlib import Path
 
 from gxformat2._scripts import ensure_format2
 from gxformat2.linting import LintContext
@@ -99,8 +100,9 @@ def lint_format2(lint_context, workflow_dict, path=None):
     from gxformat2.schema.v19_09 import load_document
     from schema_salad.exceptions import SchemaSaladException  # type: ignore
 
+    file_uri = Path(os.path.abspath(path)).as_uri()
     try:
-        load_document("file://" + os.path.abspath(path))
+        load_document(file_uri)
     except SchemaSaladException as e:
         lint_context.error("Validation failed " + str(e))
 


### PR DESCRIPTION
When running `gxwf-lint` on Windows, I had the following error:

```
> gxwf-lint .\workflow.yaml
.. ERROR: Validation failed [Errno 2] No such file or directory: ''
```

I traced  the error back to the URL parsing of `schema_salad`: 
https://github.com/common-workflow-language/schema_salad/blob/2cd30d8d5519e178d9ad2be9e3c8c4b8cc5fc694/schema_salad/fetcher.py#L73.

This gives an empty `path` when running the above command on Windows.

The input `url` is actually generated at https://github.com/galaxyproject/gxformat2/blob/71dc89883c3ac933019b61fe3978c1b7804c9167/gxformat2/lint.py#L103

The simple concatenation of `file://` gives a valid URI on Unix but not on Windows as the path gets parsed into `netloc`, giving an empty `path`:

```
>>> url = "file://" + os.path.abspath(path)
>>> url
'file://C:\\Users\\huder\\Projects\\gxformat2\\workflow.yaml'
>>> urllib.parse.urlsplit(url)
SplitResult(scheme='file', netloc='C:\\Users\\huder\\Projects\\gxformat2\\workflow.yaml', path='', query='', fragment='')
```

By using [pathlib.Path.as_uri](https://docs.python.org/fr/3/library/pathlib.html#pathlib.Path.as_uri), we can build a URI that works both for Unix and Windows:

```
>>> url = Path(os.path.abspath(path)).as_uri()
>>> url
'file:///C:/Users/huder/Projects/gxformat2/workflow.yaml'
>>> urllib.parse.urlsplit(url)
SplitResult(scheme='file', netloc='', path='/C:/Users/huder/Projects/gxformat2/workflow.yaml', query='', fragment='')
```