### PR TITLE
Support unencoded tool_state in native workflows.

### DIFF
--- a/gxformat2/converter.py
+++ b/gxformat2/converter.py
@@ -79,6 +79,7 @@ class ImportOptions:
 
     def __init__(self):
         self.deduplicate_subworkflows = False
+        self.encode_tool_state = True
 
 
 def yaml_to_workflow(has_yaml, galaxy_interface, workflow_directory, import_options=None):
@@ -322,7 +323,7 @@ def transform_input(context, step, default_name):
         if attrib in step:
             tool_state[attrib] = step[attrib]
 
-    _populate_tool_state(step, tool_state)
+    _populate_tool_state(step, tool_state, encode=context.import_options.encode_tool_state)
 
 
 def transform_pause(context, step, default_name="Pause for dataset review"):
@@ -350,7 +351,7 @@ def transform_pause(context, step, default_name="Pause for dataset review"):
 
     connect = pop_connect_from_step_dict(step)
     _populate_input_connections(context, step, connect)
-    _populate_tool_state(step, tool_state)
+    _populate_tool_state(step, tool_state, encode=context.import_options.encode_tool_state)
 
 
 def transform_subworkflow(context, step):
@@ -366,7 +367,7 @@ def transform_subworkflow(context, step):
 
     connect = pop_connect_from_step_dict(step)
     _populate_input_connections(context, step, connect)
-    _populate_tool_state(step, tool_state)
+    _populate_tool_state(step, tool_state, encode=context.import_options.encode_tool_state)
 
 
 def _runtime_value():
@@ -398,20 +399,21 @@ def transform_tool(context, step):
     # TODO: handle runtime inputs and state together.
     runtime_inputs = step.get("runtime_inputs", [])
     if "state" in step or runtime_inputs:
+        encode = context.import_options.encode_tool_state
         step_state = step.pop("state", {})
         step_state = setup_connected_values(step_state, append_to=connect)
 
         for key, value in step_state.items():
-            tool_state[key] = json.dumps(value)
+            tool_state[key] = json.dumps(value) if encode else value
         for runtime_input in runtime_inputs:
-            tool_state[runtime_input] = json.dumps(_runtime_value())
+            tool_state[runtime_input] = json.dumps(_runtime_value()) if encode else _runtime_value()
     elif "tool_state" in step:
         tool_state.update(step.get("tool_state"))
 
     # Fill in input connections
     _populate_input_connections(context, step, connect)
 
-    _populate_tool_state(step, tool_state)
+    _populate_tool_state(step, tool_state, encode=context.import_options.encode_tool_state)
 
     # Handle outputs.
     out = step.pop("out", None)
@@ -600,8 +602,8 @@ def _ensure_defaults(in_dict, defaults):
             in_dict[key] = value
 
 
-def _populate_tool_state(step, tool_state):
-    step["tool_state"] = json.dumps(tool_state)
+def _populate_tool_state(step, tool_state, encode=True):
+    step["tool_state"] = json.dumps(tool_state) if encode else tool_state
 
 
 def main(argv=None):

--- a/gxformat2/export.py
+++ b/gxformat2/export.py
@@ -166,7 +166,9 @@ def from_galaxy_native(native_workflow_dict, tool_interface=None, json_wrapper=F
 
 
 def _tool_state(step):
-    tool_state = json.loads(step["tool_state"])
+    tool_state = step["tool_state"]
+    if isinstance(tool_state, str):
+        tool_state = json.loads(tool_state)
     return tool_state
 
 

--- a/tests/test_to_format2.py
+++ b/tests/test_to_format2.py
@@ -1,8 +1,9 @@
+import json
 import os
 
 from yaml import safe_load
 
-from gxformat2.export import main
+from gxformat2.export import from_galaxy_native, main
 from ._helpers import TEST_PATH, to_example_path
 
 
@@ -36,6 +37,23 @@ def test_compact_workflow_example():
     with open(compact_path) as fh:
         wf = safe_load(fh)
     assert "position" not in wf["steps"][0]
+
+
+def test_dict_tool_state_export():
+    """Test that from_galaxy_native handles dict-form tool_state (not JSON string)."""
+    sars_example = os.path.join(TEST_PATH, "sars-cov-2-variant-calling.ga")
+    with open(sars_example) as f:
+        native_wf = json.load(f)
+
+    # Convert all tool_state from JSON strings to dicts
+    for step in native_wf["steps"].values():
+        ts = step.get("tool_state")
+        if ts and isinstance(ts, str):
+            step["tool_state"] = json.loads(ts)
+
+    # Should not raise — export handles both formats
+    result = from_galaxy_native(native_wf)
+    assert "steps" in result
 
 
 def _run_example_path(path, compact=False):

--- a/tests/test_to_native.py
+++ b/tests/test_to_native.py
@@ -2,11 +2,11 @@ import json
 import os
 
 from gxformat2._scripts import ensure_format2_from_path
-from gxformat2.converter import main
+from gxformat2.converter import ImportOptions, main, python_to_workflow
 from gxformat2.lint import lint_ga_path
 from gxformat2.linting import LintContext
-from gxformat2.yaml import ordered_dump
-from ._helpers import TEST_PATH, to_example_path
+from gxformat2.yaml import ordered_dump, ordered_load
+from ._helpers import MockGalaxyInterface, TEST_PATH, to_example_path
 from .example_wfs import (
     BASIC_WORKFLOW,
     INT_INPUT,
@@ -76,6 +76,40 @@ def test_multiple_string():
     tool_state = json.loads(multi_text_step["tool_state"])
     assert tool_state["parameter_type"] == "text"
     assert tool_state["multiple"]
+
+
+def test_unencoded_tool_state():
+    """Test that encode_tool_state=False produces dict tool_state instead of JSON string."""
+    import_options = ImportOptions()
+    import_options.encode_tool_state = False
+    format2_path = to_example_path("unencoded_basic", EXAMPLES_DIR_NAME, "gxwf.yml")
+    with open(format2_path, "w") as f:
+        f.write(BASIC_WORKFLOW)
+    with open(format2_path) as f:
+        as_python = ordered_load(f)
+    as_native = python_to_workflow(as_python, MockGalaxyInterface(), import_options=import_options)
+
+    for step in as_native["steps"].values():
+        tool_state = step.get("tool_state")
+        if tool_state is not None:
+            assert isinstance(tool_state, dict), f"Expected dict tool_state, got {type(tool_state)}"
+
+
+def test_unencoded_int_input():
+    """Test that encode_tool_state=False preserves parameter values as dicts."""
+    import_options = ImportOptions()
+    import_options.encode_tool_state = False
+    format2_path = to_example_path("unencoded_int", EXAMPLES_DIR_NAME, "gxwf.yml")
+    with open(format2_path, "w") as f:
+        f.write(INT_INPUT)
+    with open(format2_path) as f:
+        as_python = ordered_load(f)
+    as_native = python_to_workflow(as_python, MockGalaxyInterface(), import_options=import_options)
+
+    int_step = as_native["steps"]["1"]
+    tool_state = int_step["tool_state"]
+    assert isinstance(tool_state, dict)
+    assert tool_state["parameter_type"] == "integer"
 
 
 def _run_example_path(path):


### PR DESCRIPTION
Add ImportOptions.encode_tool_state flag (default True) so Format2→Native conversion can output tool_state as plain dicts instead of JSON strings. Also make Native→Format2 export handle both string and dict tool_state input.

The agent thinks Galaxy supports unencoded workflow tool states (https://github.com/galaxyproject/iwc/pull/1156#issuecomment-4076602563) but gxformat2 does not. So this is a bug fix I think. I think in the future we can swap the conversion to produce this by default but I want a bug fix for it not even being able to read these kinds of workflows first.