### PR TITLE
Use _unlabeled_input_ sentinel to preserve label=None on round-trip

### DIFF
--- a/gxformat2/_labels.py
+++ b/gxformat2/_labels.py
@@ -1,5 +1,7 @@
 """Utilities for handling unlabelled objects when translating workflow formats."""
 
+UNLABELED_INPUT_PREFIX = "_unlabeled_input_"
+
 
 class Labels:
     """Track labels assigned and generate anonymous ones."""
@@ -25,3 +27,8 @@ class Labels:
         # in Galaxy that doesn't define a label in order to great a .ga file without output
         # labels (which is completely normal).
         return not label or label.startswith("_anonymous_output_")
+
+    @staticmethod
+    def is_unlabeled_input(label) -> bool:
+        """Predicate determining if supplied label is a synthetic sentinel for an unlabeled input."""
+        return isinstance(label, str) and label.startswith(UNLABELED_INPUT_PREFIX)

--- a/gxformat2/converter.py
+++ b/gxformat2/converter.py
@@ -155,6 +155,8 @@ def _python_to_workflow(as_python, conversion_context):
             if "label" in step:
                 label = step["label"]
                 conversion_context.labels[label] = i
+                if Labels.is_unlabeled_input(label):
+                    step["label"] = None
 
             # TODO: this really should be optional in Galaxy API.
             ensure_step_position(step, i)

--- a/gxformat2/export.py
+++ b/gxformat2/export.py
@@ -52,7 +52,10 @@ def from_galaxy_native(native_workflow_dict, tool_interface=None, json_wrapper=F
         label = step.get("label")
         if not label:
             all_labeled = False
-        label_map[str(key)] = label
+        if label is None and step.get("type") in ("data_input", "data_collection_input", "parameter_input"):
+            label_map[str(key)] = f"_unlabeled_input_{step['id']}"
+        else:
+            label_map[str(key)] = label
 
     inputs = OrderedDict()
     outputs = OrderedDict()
@@ -73,9 +76,7 @@ def from_galaxy_native(native_workflow_dict, tool_interface=None, json_wrapper=F
 
         module_type = step.get("type")
         if module_type in ["data_input", "data_collection_input", "parameter_input"]:
-            # If there's no step label we use the step id as the gxformat2 step id,
-            # which then acts as the label. This does change workflows on a round-trip.
-            step_id = step["label"] if step["label"] is not None else str(step["id"])
+            step_id = step["label"] if step["label"] is not None else f"_unlabeled_input_{step['id']}"
             input_dict = {}
             tool_state = _tool_state(step)
             input_dict["type"] = native_input_to_format2_type(step, tool_state)

--- a/tests/test_to_format2.py
+++ b/tests/test_to_format2.py
@@ -1,10 +1,12 @@
+import copy
 import json
 import os
 
 from yaml import safe_load
 
+from gxformat2.converter import python_to_workflow
 from gxformat2.export import from_galaxy_native, main
-from ._helpers import TEST_PATH, to_example_path
+from ._helpers import MockGalaxyInterface, TEST_PATH, to_example_path
 
 
 def test_sars_covid_example():
@@ -54,6 +56,50 @@ def test_dict_tool_state_export():
     # Should not raise — export handles both formats
     result = from_galaxy_native(native_wf)
     assert "steps" in result
+
+
+def test_unlabeled_input_round_trip():
+    """Test that unlabeled inputs preserve label=None through round-trip."""
+    example = os.path.join(TEST_PATH, "basic_without_step_input_label.ga")
+    with open(example) as f:
+        native_wf = json.load(f)
+
+    # Verify the input step has no label
+    assert native_wf["steps"]["0"]["label"] is None
+
+    # Export to format2
+    format2 = from_galaxy_native(copy.deepcopy(native_wf))
+
+    # The format2 key should use the sentinel prefix
+    assert "_unlabeled_input_0" in format2["inputs"]
+
+    # Re-import to native
+    native_rt = python_to_workflow(copy.deepcopy(format2), MockGalaxyInterface(), None)
+
+    # The round-tripped step should have label=None, not "0" or "_unlabeled_input_0"
+    assert native_rt["steps"]["0"]["label"] is None
+
+
+def test_unlabeled_input_connections_round_trip():
+    """Test that connections to unlabeled inputs survive round-trip."""
+    example = os.path.join(TEST_PATH, "basic_without_step_input_label.ga")
+    with open(example) as f:
+        native_wf = json.load(f)
+
+    format2 = from_galaxy_native(copy.deepcopy(native_wf))
+
+    # The cat step should reference the unlabeled input via sentinel
+    cat_step = format2["steps"][0]
+    assert "_unlabeled_input_0" in str(cat_step["in"]["input1"]["source"])
+
+    # Re-import and verify connection still works
+    native_rt = python_to_workflow(copy.deepcopy(format2), MockGalaxyInterface(), None)
+    cat_step_rt = native_rt["steps"]["1"]
+    input_conn = cat_step_rt["input_connections"]["input1"]
+    if isinstance(input_conn, list):
+        assert input_conn[0]["id"] == 0
+    else:
+        assert input_conn["id"] == 0
 
 
 def _run_example_path(path, compact=False):


### PR DESCRIPTION
Fixes #143. Unlabeled input steps now use a sentinel prefix during format2 export/import instead of the raw step index, preventing synthetic labels from being assigned on round-trip.