### PR TITLE
Enforce Literal types for native workflow marker fields

### DIFF
--- a/gxformat2/examples/expectations/lint_native.yml
+++ b/gxformat2/examples/expectations/lint_native.yml
@@ -106,6 +106,15 @@ test_lint_native_output_no_label:
 
 # --- Report validation ---
 
+test_lint_native_missing_marker:
+  fixture: synthetic-missing-marker.ga
+  operation: lint_native
+  assertions:
+    - path: [error_count]
+      value: 1
+    - path: [errors, 0]
+      value_contains: "a_galaxy_workflow"
+
 test_lint_native_report_clean:
   fixture: synthetic-lint-report.ga
   operation: lint_native

--- a/gxformat2/examples/expectations/validate_native.yml
+++ b/gxformat2/examples/expectations/validate_native.yml
@@ -207,3 +207,23 @@ test_report_bad_type_rejected_native_strict:
   fixture: synthetic-lint-report-bad-type.ga
   operation: validate_native_strict
   expect_error: true
+
+test_bad_marker_rejected_native:
+  fixture: synthetic-lint-bad-marker.ga
+  operation: validate_native
+  expect_error: true
+
+test_bad_marker_rejected_native_strict:
+  fixture: synthetic-lint-bad-marker.ga
+  operation: validate_native_strict
+  expect_error: true
+
+test_bad_format_version_rejected_native:
+  fixture: synthetic-lint-bad-format-version.ga
+  operation: validate_native
+  expect_error: true
+
+test_bad_format_version_rejected_native_strict:
+  fixture: synthetic-lint-bad-format-version.ga
+  operation: validate_native_strict
+  expect_error: true

--- a/gxformat2/schema/native.py
+++ b/gxformat2/schema/native.py
@@ -391,8 +391,8 @@ added without version bumps."""
 
     name: None | str = Field(default=None, description="Workflow display name.")
     class_: Literal["NativeGalaxyWorkflow"] = Field(default="NativeGalaxyWorkflow", alias="class")
-    a_galaxy_workflow: str = Field(description="Format marker. Always the string ``\"true\"``.")
-    format_version: str = Field(alias="format-version", description="Format version. Always ``\"0.1\"`` currently. In the JSON document this field is written as ``format-version``.")
+    a_galaxy_workflow: Literal['true'] = Field(description="Format marker. Always the string ``\"true\"``.")
+    format_version: Literal['0.1'] = Field(alias="format-version", description="Format version. Always ``\"0.1\"`` currently. In the JSON document this field is written as ``format-version``.")
     annotation: None | str = Field(default=None, description="Human-readable workflow description.")
     tags: None | list[str] = Field(default=None, description="Classification tags for the workflow.")
     version: None | int = Field(default=None, description="Internal revision counter.")

--- a/gxformat2/schema/native_strict.py
+++ b/gxformat2/schema/native_strict.py
@@ -391,8 +391,8 @@ added without version bumps."""
 
     name: None | str = Field(default=None, description="Workflow display name.")
     class_: Literal["NativeGalaxyWorkflow"] = Field(default="NativeGalaxyWorkflow", alias="class")
-    a_galaxy_workflow: str = Field(description="Format marker. Always the string ``\"true\"``.")
-    format_version: str = Field(alias="format-version", description="Format version. Always ``\"0.1\"`` currently. In the JSON document this field is written as ``format-version``.")
+    a_galaxy_workflow: Literal['true'] = Field(description="Format marker. Always the string ``\"true\"``.")
+    format_version: Literal['0.1'] = Field(alias="format-version", description="Format version. Always ``\"0.1\"`` currently. In the JSON document this field is written as ``format-version``.")
     annotation: None | str = Field(default=None, description="Human-readable workflow description.")
     tags: None | list[str] = Field(default=None, description="Classification tags for the workflow.")
     version: None | int = Field(default=None, description="Internal revision counter.")

--- a/schema/native_v0_1/workflow.yml
+++ b/schema/native_v0_1/workflow.yml
@@ -810,6 +810,7 @@ $graph:
         symbols: [ gxnative:NativeGalaxyWorkflow ]
     - name: a_galaxy_workflow
       type: string
+      pydantic:type: "Literal['true']"
       doc: |
         Format marker. Always the string ``"true"``.
     - name: format_version
@@ -817,6 +818,7 @@ $graph:
       jsonldPredicate:
         _id: "gxnative:format_version"
       pydantic:alias: "format-version"
+      pydantic:type: "Literal['0.1']"
       doc: |
         Format version. Always ``"0.1"`` currently.
         In the JSON document this field is written as ``format-version``.


### PR DESCRIPTION
Add pydantic:type Literal constraints for a_galaxy_workflow and format_version in native schema, rejecting invalid values at validation time. Add interop tests for validate/lint coverage gaps.