### PR TITLE
Linting Improvements

### DIFF
--- a/gxformat2/examples/catalog.yml
+++ b/gxformat2/examples/catalog.yml
@@ -8,6 +8,7 @@
     - tests/test_to_native.py
     - tests/test_export_abstract.py
     - tests/test_interop_tests.py
+    - tests/test_schema_rules_catalog.py
 
 - file: format2/synthetic-nested-subworkflow.gxwf.yml
   origin: synthetic
@@ -31,6 +32,7 @@
     - tests/test_lint.py
     - tests/test_basic.py
     - tests/test_interop_tests.py
+    - tests/test_schema_rules_catalog.py
 
 - file: native/real-hacked-unicycler-assembly-with-tags.ga
   origin: real-hacked
@@ -431,24 +433,35 @@
   format: format2
   tests:
     - tests/test_interop_tests.py
+    - tests/test_schema_rules_catalog.py
 
 - file: format2/synthetic-missing-steps.gxwf.yml
   origin: synthetic
   format: format2
   tests:
     - tests/test_interop_tests.py
+    - tests/test_schema_rules_catalog.py
 
 - file: native/synthetic-extra-field.ga
   origin: synthetic
   format: native
   tests:
     - tests/test_interop_tests.py
+    - tests/test_schema_rules_catalog.py
 
 - file: native/synthetic-missing-marker.ga
   origin: synthetic
   format: native
   tests:
     - tests/test_interop_tests.py
+    - tests/test_schema_rules_catalog.py
+
+- file: native/real-hacked-basic-missing-format-version.ga
+  origin: real-hacked
+  format: native
+  description: real-basic-without-step-input-label.ga with format-version removed.
+  tests:
+    - tests/test_schema_rules_catalog.py
 
 # --- lint error/warning fixture files ---
 
@@ -521,6 +534,7 @@
   description: Report with non-string markdown (integer) — pydantic rejects.
   tests:
     - tests/test_interop_tests.py
+    - tests/test_schema_rules_catalog.py
 
 - file: native/synthetic-lint-no-steps.ga
   origin: synthetic
@@ -535,6 +549,7 @@
   description: Invalid format-version value — triggers lint error.
   tests:
     - tests/test_interop_tests.py
+    - tests/test_schema_rules_catalog.py
 
 - file: native/synthetic-lint-bad-marker.ga
   origin: synthetic
@@ -542,6 +557,7 @@
   description: a_galaxy_workflow set to "false" — triggers lint error.
   tests:
     - tests/test_interop_tests.py
+    - tests/test_schema_rules_catalog.py
 
 - file: native/synthetic-lint-non-integer-step.ga
   origin: synthetic
@@ -577,6 +593,7 @@
   description: Report with non-string markdown (integer) — pydantic rejects.
   tests:
     - tests/test_interop_tests.py
+    - tests/test_schema_rules_catalog.py
 
 # --- best practices lint fixture files ---
 

--- a/gxformat2/examples/expectations/lint_native.yml
+++ b/gxformat2/examples/expectations/lint_native.yml
@@ -83,6 +83,10 @@ test_lint_native_non_integer_step_key:
       value: 1
     - path: [errors, 0]
       value_contains: "integer"
+    - path: [errors, 0, linter]
+      value: NativeStepKeyNotInteger
+    - path: [errors, 0, json_pointer]
+      value_contains: "/steps/"
 
 test_lint_native_nested_no_steps:
   fixture: synthetic-lint-nested-no-steps.ga

--- a/gxformat2/examples/native/real-hacked-basic-missing-format-version.ga
+++ b/gxformat2/examples/native/real-hacked-basic-missing-format-version.ga
@@ -1,0 +1,56 @@
+{
+    "steps": {
+        "0": {
+            "type": "data_input",
+            "label": null,
+            "id": 0,
+            "position": {
+                "left": 0,
+                "top": 0
+            },
+            "annotation": "input doc",
+            "input_connections": {},
+            "inputs": [
+                {
+                    "name": "the_input",
+                    "description": ""
+                }
+            ],
+            "tool_state": "{\"name\": \"the_input\"}"
+        },
+        "1": {
+            "tool_id": "cat1",
+            "label": "cat",
+            "id": 1,
+            "position": {
+                "left": 10,
+                "top": 10
+            },
+            "type": "tool",
+            "name": "cat1",
+            "post_job_actions": {},
+            "tool_version": null,
+            "annotation": "cat doc",
+            "input_connections": {
+                "input1": [
+                    {
+                        "id": 0,
+                        "output_name": "output"
+                    }
+                ]
+            },
+            "tool_state": "{\"__page__\": 0}",
+            "workflow_outputs": [
+                {
+                    "output_name": "out_file1",
+                    "label": "the_output",
+                    "uuid": null
+                }
+            ]
+        }
+    },
+    "a_galaxy_workflow": "true",
+    "name": "Simple workflow",
+    "uuid": "f7f9fdbe-fb11-4721-be02-097709beb86f",
+    "annotation": "Simple workflow that no-op cats a file and then selects 10 random lines.\n"
+}

--- a/gxformat2/lint.py
+++ b/gxformat2/lint.py
@@ -11,6 +11,7 @@ from urllib.parse import urlparse
 
 from pydantic import ValidationError
 
+from gxformat2.lint_rules import NativeStepKeyNotInteger
 from gxformat2.linting import LintContext
 from gxformat2.markdown_parse import validate_galaxy_markdown
 from gxformat2.normalized import (
@@ -72,7 +73,11 @@ def lint_ga(lint_context, nnw, raw_dict: dict | None = None, path=None):
 
     for order_index_str, step in nnw.steps.items():
         if not order_index_str.isdigit():
-            lint_context.error("expected step_key to be integer not [{value}]", value=order_index_str)
+            lint_context.error(
+                f"expected step_key to be integer not [{order_index_str}]",
+                linter=NativeStepKeyNotInteger,
+                json_pointer=f"/steps/{order_index_str}",
+            )
 
         for workflow_output in step.workflow_outputs:
             found_outputs = True

--- a/gxformat2/lint.py
+++ b/gxformat2/lint.py
@@ -40,8 +40,17 @@ LINT_FAILED_NO_OUTPUTS = "Workflow contained no outputs"
 LINT_FAILED_OUTPUT_NO_LABEL = "Workflow contained output without a label"
 
 
-def lint_ga(lint_context, nnw: NormalizedNativeWorkflow, raw_dict: dict | None = None):
-    """Lint a native Galaxy workflow and populate the corresponding LintContext."""
+def lint_ga(lint_context, nnw, raw_dict: dict | None = None, path=None):
+    """Lint a native Galaxy workflow and populate the corresponding LintContext.
+
+    Backward-compat: ``nnw`` may be a raw dict (legacy Planemo signature), in
+    which case it is expanded to ``NormalizedNativeWorkflow`` internally.
+    ``path`` is accepted for Planemo compatibility and currently ignored.
+    """
+    if isinstance(nnw, dict):
+        if raw_dict is None:
+            raw_dict = nnw
+        nnw = ensure_native(nnw)
     # Check fields that the model defaults mask
     if raw_dict is not None:
         if "a_galaxy_workflow" not in raw_dict:
@@ -103,8 +112,17 @@ def lint_format2_path(lint_context, path):
     return lint_format2(lint_context, nf2, raw_dict=workflow_dict)
 
 
-def lint_format2(lint_context, nf2: NormalizedFormat2, raw_dict: dict | None = None):
-    """Lint a Format 2 Galaxy workflow and populate the corresponding LintContext."""
+def lint_format2(lint_context, nf2, raw_dict: dict | None = None, path=None):
+    """Lint a Format 2 Galaxy workflow and populate the corresponding LintContext.
+
+    Backward-compat: ``nf2`` may be a raw dict (legacy Planemo signature), in
+    which case it is expanded to ``NormalizedFormat2`` internally. ``path`` is
+    accepted for Planemo compatibility and currently ignored.
+    """
+    if isinstance(nf2, dict):
+        if raw_dict is None:
+            raw_dict = nf2
+        nf2 = ensure_format2(nf2, expand=True)
     if raw_dict is not None:
         if "steps" not in raw_dict:
             lint_context.error("expected to find key [steps] but absent")

--- a/gxformat2/lint_profiles.py
+++ b/gxformat2/lint_profiles.py
@@ -16,6 +16,8 @@ LINT_PROFILES_PATH = os.path.join(os.path.dirname(__file__), "lint_profiles.yml"
 
 
 class LintProfile(BaseModel):
+    """Named set of lint-rule IDs loaded from lint_profiles.yml."""
+
     id: str
     description: str = ""
     rules: List[str]

--- a/gxformat2/lint_profiles.py
+++ b/gxformat2/lint_profiles.py
@@ -1,0 +1,51 @@
+"""Lint profile catalog loader.
+
+Profiles group lint-rule IDs into named sets (``structural``,
+``best-practices``, ``release``). Unknown IDs are tolerated — audit tooling
+compares against the registered ``Linter`` subclasses to flag unimplemented
+entries as INFO.
+"""
+
+import os
+from typing import Dict, List, Set
+
+import yaml
+from pydantic import BaseModel
+
+LINT_PROFILES_PATH = os.path.join(os.path.dirname(__file__), "lint_profiles.yml")
+
+
+class LintProfile(BaseModel):
+    id: str
+    description: str = ""
+    rules: List[str]
+
+
+def load_lint_profiles() -> List[LintProfile]:
+    """Parse lint_profiles.yml into validated ``LintProfile`` models."""
+    with open(LINT_PROFILES_PATH) as f:
+        raw = yaml.safe_load(f) or {}
+    profiles: List[LintProfile] = []
+    for profile_id, body in raw.items():
+        profiles.append(LintProfile(id=profile_id, **body))
+    return profiles
+
+
+def lint_profiles_by_id() -> Dict[str, LintProfile]:
+    """Return profiles keyed by id."""
+    return {p.id: p for p in load_lint_profiles()}
+
+
+def rules_for_profile(profile_id: str) -> List[str]:
+    """Return the ordered rule ID list for a named profile."""
+    return lint_profiles_by_id()[profile_id].rules
+
+
+def iwc_rule_ids() -> Set[str]:
+    """Union of structural, best-practices, and release rule IDs."""
+    profiles = lint_profiles_by_id()
+    rule_ids: Set[str] = set()
+    for name in ("structural", "best-practices", "release"):
+        if name in profiles:
+            rule_ids.update(profiles[name].rules)
+    return rule_ids

--- a/gxformat2/lint_profiles.yml
+++ b/gxformat2/lint_profiles.yml
@@ -1,0 +1,41 @@
+# Lint profile catalog.
+#
+# Profiles group lint-rule IDs into named sets. Profiles apply only to
+# lint rules (schema rules always run as part of validate_*). Unknown IDs
+# are tolerated by the loader; audit tooling can flag them.
+#
+# Rule IDs mirror the ``Linter`` class names in gxformat2/lint_rules.py.
+
+structural:
+  description: "Checks that prevent execution or indicate structural breakage."
+  rules:
+    - NativeStepKeyNotInteger
+    - StepExportError
+    - StepUsesTestToolshed
+    - WorkflowHasNoOutputs
+    - WorkflowOutputMissingLabel
+    - OutputSourceNotFound
+    - InputDefaultTypeInvalid
+    - ReportMarkdownInvalid
+
+best-practices:
+  description: "Deviations from recommended authoring practice."
+  rules:
+    - WorkflowMissingAnnotation
+    - WorkflowMissingCreator
+    - WorkflowMissingLicense
+    - CreatorIdentifierNotURI
+    - StepMissingLabel
+    - StepMissingAnnotation
+    - StepInputDisconnected
+    - StepToolStateUntypedParameter
+    - StepPJAUntypedParameter
+    - TrainingWorkflowMissingTag
+    - TrainingWorkflowWrongTopic
+    - TrainingWorkflowMissingDoc
+    - TrainingWorkflowEmptyDoc
+
+release:
+  description: "Additional gates for workflows being released."
+  rules:
+    - WorkflowMissingRelease

--- a/gxformat2/lint_rules.py
+++ b/gxformat2/lint_rules.py
@@ -1,0 +1,16 @@
+"""Lint rule classes.
+
+Each ``Linter`` subclass carries metadata only (severity, applies_to,
+profile). Emission happens in ``gxformat2/lint.py`` via
+``LintContext.warn`` / ``LintContext.error`` with ``linter=<Subclass>``.
+"""
+
+from gxformat2.linting import Linter
+
+
+class NativeStepKeyNotInteger(Linter):
+    """Native workflow step keys must be string representations of integers."""
+
+    severity = "error"
+    applies_to = ("native",)
+    profile = "structural"

--- a/gxformat2/linting.py
+++ b/gxformat2/linting.py
@@ -1,58 +1,131 @@
 """Generic utilities for linting.
 
-Largely derived in large part from galaxy.tool_util.lint.
+Largely derived from galaxy.tool_util.lint. ``LintMessage`` is a ``str``
+subclass so existing code that treats ``warn_messages`` / ``error_messages``
+as lists of strings keeps working; new metadata (``level``, ``linter``,
+``json_pointer``) is accessible as attributes.
 """
 
-LEVEL_ALL = "all"
-LEVEL_WARN = "warn"
-LEVEL_ERROR = "error"
+from __future__ import annotations
+
+import enum
+from typing import ClassVar, List, Optional, Tuple, Union
+
+
+class LintLevel(str, enum.Enum):
+    """Lint severity levels."""
+
+    ERROR = "error"
+    WARN = "warn"
+    ALL = "all"
+
+
+# Back-compat string constants.
+LEVEL_ALL = LintLevel.ALL.value
+LEVEL_WARN = LintLevel.WARN.value
+LEVEL_ERROR = LintLevel.ERROR.value
 DEFAULT_TRAINING_LINT = None
+
+
+class LintMessage(str):
+    """A single lint emission: prose + structured metadata.
+
+    Subclassing ``str`` keeps ``"substring" in message`` and
+    ``str(message)`` working for existing callers/tests.
+    """
+
+    level: str
+    linter: Optional[str]
+    json_pointer: str
+
+    def __new__(
+        cls,
+        message: str,
+        *,
+        level: str = LEVEL_WARN,
+        linter: Optional[str] = None,
+        json_pointer: str = "",
+    ) -> "LintMessage":
+        self = super().__new__(cls, message)
+        self.level = level
+        self.linter = linter
+        self.json_pointer = json_pointer
+        return self
+
+
+class Linter:
+    """Metadata-only base class for lint rules.
+
+    Subclasses carry class-level metadata; emission is performed by
+    ``LintContext.warn`` / ``LintContext.error`` with ``linter=SubclassName``.
+    """
+
+    severity: ClassVar[str] = "warning"
+    applies_to: ClassVar[Tuple[str, ...]] = ()
+    profile: ClassVar[str] = "structural"
+
+
+def _escape_pointer_segment(segment) -> str:
+    """Escape an RFC 6901 JSON Pointer segment."""
+    return str(segment).replace("~", "~0").replace("/", "~1")
 
 
 class LintContext:
     """Track running status (state) of linting."""
 
-    def __init__(self, level=LEVEL_WARN, training_topic=DEFAULT_TRAINING_LINT, _prefix=""):
+    def __init__(self, level=LEVEL_WARN, training_topic=DEFAULT_TRAINING_LINT, _pointer: str = ""):
         """Create LintContext with specified 'level' (currently unused)."""
         self.level = level
         self.training_topic = training_topic
         self.found_errors = False
         self.found_warns = False
-        self._prefix = _prefix
+        self._pointer = _pointer
 
-        # self.valid_messages = []
-        # self.info_messages = []
-        self.warn_messages = []
-        self.error_messages = []
+        self.warn_messages: List[LintMessage] = []
+        self.error_messages: List[LintMessage] = []
 
-    def child(self, prefix):
-        """Create child context that prefixes messages and shares parent message lists."""
-        full_prefix = f"{self._prefix}[{prefix}] " if not self._prefix else f"{self._prefix[:-1]} > {prefix}] "
-        child_ctx = LintContext(level=self.level, training_topic=self.training_topic, _prefix=full_prefix)
+    def child(self, pointer_segment) -> "LintContext":
+        """Create child context whose default json_pointer is prefixed."""
+        new_pointer = f"{self._pointer}/{_escape_pointer_segment(pointer_segment)}"
+        child_ctx = LintContext(
+            level=self.level,
+            training_topic=self.training_topic,
+            _pointer=new_pointer,
+        )
         child_ctx.warn_messages = self.warn_messages
         child_ctx.error_messages = self.error_messages
         return child_ctx
 
-    def __handle_message(self, message_list, message, *args, **kwds):
-        if kwds or args:
-            message = message.format(*args, **kwds)
-        message_list.append(f"{self._prefix}{message}")
-
-    # def valid(self, message, *args, **kwds):
-    #     self.__handle_message(self.valid_messages, message, *args, **kwds)
-
-    # def info(self, message, *args, **kwds):
-    #     self.__handle_message(self.info_messages, message, *args, **kwds)
-
-    def error(self, message, *args, **kwds):
+    def error(
+        self,
+        message: str,
+        *args,
+        linter: Union[type, str, None] = None,
+        json_pointer: Optional[str] = None,
+        **kwds,
+    ) -> None:
         """Track a linting error - a serious problem with the artifact preventing execution."""
-        self.__handle_message(self.error_messages, message, *args, **kwds)
+        self._emit(self.error_messages, LEVEL_ERROR, message, args, kwds, linter, json_pointer)
 
-    def warn(self, message, *args, **kwds):
+    def warn(
+        self,
+        message: str,
+        *args,
+        linter: Union[type, str, None] = None,
+        json_pointer: Optional[str] = None,
+        **kwds,
+    ) -> None:
         """Track a linting warning - a deviation from best practices."""
-        self.__handle_message(self.warn_messages, message, *args, **kwds)
+        self._emit(self.warn_messages, LEVEL_WARN, message, args, kwds, linter, json_pointer)
 
-    def print_messages(self):
+    def _emit(self, message_list, level, message, args, kwds, linter, json_pointer) -> None:
+        if args or kwds:
+            message = message.format(*args, **kwds)
+        pointer = json_pointer if json_pointer is not None else self._pointer
+        linter_name = linter.__name__ if isinstance(linter, type) else linter
+        message_list.append(LintMessage(message, level=level, linter=linter_name, json_pointer=pointer))
+
+    def print_messages(self) -> None:
         """Print error messages and update state at the end of linting."""
         for message in self.error_messages:
             self.found_errors = True
@@ -62,9 +135,3 @@ class LintContext:
             for message in self.warn_messages:
                 self.found_warns = True
                 print(f".. WARNING: {message}")
-
-        if self.level == LEVEL_ALL:
-            for message in self.info_messages:
-                print(f".. INFO: {message}")
-            for message in self.valid_messages:
-                print(f".. CHECK: {message}")

--- a/gxformat2/linting.py
+++ b/gxformat2/linting.py
@@ -46,6 +46,7 @@ class LintMessage(str):
         linter: Optional[str] = None,
         json_pointer: str = "",
     ) -> "LintMessage":
+        """Construct a ``LintMessage`` with prose and structured metadata."""
         self = super().__new__(cls, message)
         self.level = level
         self.linter = linter

--- a/gxformat2/schema_rules.py
+++ b/gxformat2/schema_rules.py
@@ -17,11 +17,15 @@ SCHEMA_RULES_PATH = os.path.join(os.path.dirname(__file__), "schema_rules.yml")
 
 
 class Severity(str, Enum):
+    """Rule severity level."""
+
     error = "error"
     warning = "warning"
 
 
 class AppliesTo(str, Enum):
+    """Which workflow format a schema rule applies to."""
+
     format2 = "format2"
     native = "native"
 
@@ -40,11 +44,15 @@ class Scope(str, Enum):
 
 
 class SchemaRuleTests(BaseModel):
+    """Positive/negative fixture references for a schema rule."""
+
     positive: List[str]
     negative: List[str]
 
 
 class SchemaRule(BaseModel):
+    """Declarative schema-rule entry loaded from schema_rules.yml."""
+
     id: str
     severity: Severity
     applies_to: List[AppliesTo]

--- a/gxformat2/schema_rules.py
+++ b/gxformat2/schema_rules.py
@@ -1,0 +1,63 @@
+"""Schema-rule catalog loader.
+
+Schema rules describe checks already enforced by the pydantic decode layer.
+Each rule ships with positive and negative fixtures; the catalog contract is
+tested end-to-end by running fixtures through validators — not by inspecting
+ValidationError shapes.
+"""
+
+import os
+from enum import Enum
+from typing import List
+
+import yaml
+from pydantic import BaseModel
+
+SCHEMA_RULES_PATH = os.path.join(os.path.dirname(__file__), "schema_rules.yml")
+
+
+class Severity(str, Enum):
+    error = "error"
+    warning = "warning"
+
+
+class AppliesTo(str, Enum):
+    format2 = "format2"
+    native = "native"
+
+
+class Scope(str, Enum):
+    """Validator flavors that reject the negative fixture.
+
+    - ``both``: both lax and strict reject (e.g. missing required field).
+    - ``strict``: only strict rejects (e.g. unknown extra field).
+    - ``lax``: only lax rejects — unusual, reserved for completeness.
+    """
+
+    both = "both"
+    strict = "strict"
+    lax = "lax"
+
+
+class SchemaRuleTests(BaseModel):
+    positive: List[str]
+    negative: List[str]
+
+
+class SchemaRule(BaseModel):
+    id: str
+    severity: Severity
+    applies_to: List[AppliesTo]
+    scope: Scope
+    description: str = ""
+    tests: SchemaRuleTests
+
+
+def load_schema_rules() -> List[SchemaRule]:
+    """Parse schema_rules.yml into validated SchemaRule models."""
+    with open(SCHEMA_RULES_PATH) as f:
+        raw = yaml.safe_load(f)
+    rules: List[SchemaRule] = []
+    for rule_id, body in raw.items():
+        rules.append(SchemaRule(id=rule_id, **body))
+    return rules

--- a/gxformat2/schema_rules.yml
+++ b/gxformat2/schema_rules.yml
@@ -1,0 +1,69 @@
+# Schema rule catalog.
+#
+# Each entry keys a schema-decode-enforced rule. Positive fixtures must pass
+# both lax and strict validation; negative fixtures must fail per `scope`.
+# Catalog contract is verified end-to-end by tests/test_schema_rules_catalog.py;
+# no pydantic error shapes are introspected.
+
+Format2MissingSteps:
+  severity: error
+  applies_to: [format2]
+  scope: both
+  description: "Format2 workflow missing required `steps` field."
+  tests:
+    positive: [synthetic-basic.gxwf.yml]
+    negative: [synthetic-missing-steps.gxwf.yml]
+
+NativeMissingMarker:
+  severity: error
+  applies_to: [native]
+  scope: both
+  description: "Native workflow missing required `a_galaxy_workflow` marker."
+  tests:
+    positive: [real-unicycler-assembly.ga]
+    negative: [synthetic-missing-marker.ga]
+
+NativeMarkerNotTrue:
+  severity: error
+  applies_to: [native]
+  scope: both
+  description: "`a_galaxy_workflow` must be literal string \"true\"."
+  tests:
+    positive: [real-unicycler-assembly.ga]
+    negative: [synthetic-lint-bad-marker.ga]
+
+NativeMissingFormatVersion:
+  severity: error
+  applies_to: [native]
+  scope: both
+  description: "Native workflow missing required `format-version` field."
+  tests:
+    positive: [real-unicycler-assembly.ga]
+    negative: [real-hacked-basic-missing-format-version.ga]
+
+NativeFormatVersionNotSupported:
+  severity: error
+  applies_to: [native]
+  scope: both
+  description: "`format-version` must be literal string \"0.1\"."
+  tests:
+    positive: [real-unicycler-assembly.ga]
+    negative: [synthetic-lint-bad-format-version.ga]
+
+ReportMarkdownNotString:
+  severity: error
+  applies_to: [format2, native]
+  scope: both
+  description: "Workflow `report.markdown` must be a string."
+  tests:
+    positive: [synthetic-basic.gxwf.yml, real-unicycler-assembly.ga]
+    negative: [synthetic-lint-report-bad-type.gxwf.yml, synthetic-lint-report-bad-type.ga]
+
+SchemaStrictExtraField:
+  severity: warning
+  applies_to: [format2, native]
+  scope: strict
+  description: "Unknown field present on a closed record under strict validation."
+  tests:
+    positive: [synthetic-basic.gxwf.yml, real-unicycler-assembly.ga]
+    negative: [synthetic-extra-field.gxwf.yml, synthetic-extra-field.ga]

--- a/gxformat2/validators.py
+++ b/gxformat2/validators.py
@@ -14,18 +14,22 @@ from gxformat2.schema.native_strict import NativeGalaxyWorkflow as NativeStrict
 
 
 def validate_format2(wf_dict):
+    """Validate a Format2 workflow dict with the lax (open) schema."""
     return Format2Lax.model_validate(wf_dict)
 
 
 def validate_format2_strict(wf_dict):
+    """Validate a Format2 workflow dict with the strict (closed) schema."""
     return Format2Strict.model_validate(wf_dict)
 
 
 def validate_native(wf_dict):
+    """Validate a native Galaxy workflow dict with the lax (open) schema."""
     return NativeLax.model_validate(wf_dict)
 
 
 def validate_native_strict(wf_dict):
+    """Validate a native Galaxy workflow dict with the strict (closed) schema."""
     return NativeStrict.model_validate(wf_dict)
 
 

--- a/gxformat2/validators.py
+++ b/gxformat2/validators.py
@@ -1,0 +1,40 @@
+"""Shared pydantic-validator dispatch for workflow dict inputs.
+
+Callers pass a parsed workflow dict and get a pydantic model back (or a
+ValidationError). Used by the declarative-operation runner and the
+schema-rule catalog runner.
+"""
+
+from typing import Callable
+
+from gxformat2.schema.gxformat2 import GalaxyWorkflow as Format2Lax
+from gxformat2.schema.gxformat2_strict import GalaxyWorkflow as Format2Strict
+from gxformat2.schema.native import NativeGalaxyWorkflow as NativeLax
+from gxformat2.schema.native_strict import NativeGalaxyWorkflow as NativeStrict
+
+
+def validate_format2(wf_dict):
+    return Format2Lax.model_validate(wf_dict)
+
+
+def validate_format2_strict(wf_dict):
+    return Format2Strict.model_validate(wf_dict)
+
+
+def validate_native(wf_dict):
+    return NativeLax.model_validate(wf_dict)
+
+
+def validate_native_strict(wf_dict):
+    return NativeStrict.model_validate(wf_dict)
+
+
+def validator_for_fixture(fixture_name: str, strict: bool) -> Callable[[dict], object]:
+    """Pick the validator matching a fixture filename's format.
+
+    `.ga` → native; anything else → format2. `strict` picks the closed-schema
+    flavor that rejects unknown fields.
+    """
+    if fixture_name.endswith(".ga"):
+        return validate_native_strict if strict else validate_native
+    return validate_format2_strict if strict else validate_format2

--- a/tests/test_interop_tests.py
+++ b/tests/test_interop_tests.py
@@ -26,27 +26,13 @@ from gxformat2.normalized import (
 )
 from gxformat2.normalized._conversion import ExpandedFormat2
 from gxformat2.normalized._native import NormalizedNativeWorkflow
-from gxformat2.schema.gxformat2 import GalaxyWorkflow as Format2Lax
-from gxformat2.schema.gxformat2_strict import GalaxyWorkflow as Format2Strict
-from gxformat2.schema.native import NativeGalaxyWorkflow as NativeLax
-from gxformat2.schema.native_strict import NativeGalaxyWorkflow as NativeStrict
 from gxformat2.testing import DeclarativeTestSuite
-
-
-def _validate_format2(wf_dict):
-    return Format2Lax.model_validate(wf_dict)
-
-
-def _validate_format2_strict(wf_dict):
-    return Format2Strict.model_validate(wf_dict)
-
-
-def _validate_native(wf_dict):
-    return NativeLax.model_validate(wf_dict)
-
-
-def _validate_native_strict(wf_dict):
-    return NativeStrict.model_validate(wf_dict)
+from gxformat2.validators import (
+    validate_format2,
+    validate_format2_strict,
+    validate_native,
+    validate_native_strict,
+)
 
 
 def _lint_format2(wf_dict):
@@ -123,10 +109,10 @@ OPERATIONS: Dict[str, Callable[..., Any]] = {
     "to_native": to_native,
     "ensure_format2": ensure_format2,
     "ensure_native": ensure_native,
-    "validate_format2": _validate_format2,
-    "validate_format2_strict": _validate_format2_strict,
-    "validate_native": _validate_native,
-    "validate_native_strict": _validate_native_strict,
+    "validate_format2": validate_format2,
+    "validate_format2_strict": validate_format2_strict,
+    "validate_native": validate_native,
+    "validate_native_strict": validate_native_strict,
     "lint_format2": _lint_format2,
     "lint_native": _lint_native,
     "lint_best_practices_format2": _lint_best_practices_format2,

--- a/tests/test_lint_planemo_compat.py
+++ b/tests/test_lint_planemo_compat.py
@@ -1,0 +1,45 @@
+"""Back-compat shim tests for the legacy Planemo signature.
+
+Planemo calls ``lint_format2(ctx, workflow_dict, path=path)`` and
+``lint_ga(ctx, workflow_dict, path=path)`` with a raw dict. The migration to
+normalized models would have broken Planemo; this exercises the shim that
+accepts either a dict or a normalized model.
+"""
+
+from gxformat2.examples import load
+from gxformat2.lint import lint_format2, lint_ga
+from gxformat2.linting import LintContext
+
+
+def test_lint_ga_accepts_raw_dict_and_path():
+    ctx = LintContext()
+    wf_dict = load("real-unicycler-assembly.ga")
+    lint_ga(ctx, wf_dict, path="/fake/path.ga")
+    assert ctx.error_messages == []
+
+
+def test_lint_format2_accepts_raw_dict_and_path():
+    ctx = LintContext()
+    wf_dict = load("synthetic-basic.gxwf.yml")
+    lint_format2(ctx, wf_dict, path="/fake/path.gxwf.yml")
+    assert ctx.error_messages == []
+
+
+def test_lint_ga_still_accepts_normalized_model():
+    from gxformat2.normalized import ensure_native
+
+    ctx = LintContext()
+    wf_dict = load("real-unicycler-assembly.ga")
+    nnw = ensure_native(wf_dict)
+    lint_ga(ctx, nnw, raw_dict=wf_dict)
+    assert ctx.error_messages == []
+
+
+def test_lint_format2_still_accepts_normalized_model():
+    from gxformat2.normalized import ensure_format2
+
+    ctx = LintContext()
+    wf_dict = load("synthetic-basic.gxwf.yml")
+    nf2 = ensure_format2(wf_dict, expand=True)
+    lint_format2(ctx, nf2, raw_dict=wf_dict)
+    assert ctx.error_messages == []

--- a/tests/test_lint_profiles.py
+++ b/tests/test_lint_profiles.py
@@ -1,0 +1,49 @@
+"""Integrity tests for the lint profile catalog."""
+
+from gxformat2.lint_profiles import (
+    iwc_rule_ids,
+    LINT_PROFILES_PATH,
+    lint_profiles_by_id,
+    load_lint_profiles,
+    rules_for_profile,
+)
+
+
+def test_catalog_loads():
+    profiles = load_lint_profiles()
+    assert profiles, "lint_profiles.yml is empty"
+
+
+def test_three_canonical_profiles_present():
+    ids = {p.id for p in load_lint_profiles()}
+    assert {"structural", "best-practices", "release"} <= ids
+
+
+def test_rules_for_profile_returns_list():
+    rules = rules_for_profile("structural")
+    assert "NativeStepKeyNotInteger" in rules
+
+
+def test_iwc_union():
+    union = iwc_rule_ids()
+    structural = set(rules_for_profile("structural"))
+    best_practices = set(rules_for_profile("best-practices"))
+    release = set(rules_for_profile("release"))
+    assert union == structural | best_practices | release
+
+
+def test_no_duplicate_ids_within_profile():
+    for profile in load_lint_profiles():
+        assert len(profile.rules) == len(set(profile.rules)), f"profile {profile.id} has duplicate rule IDs"
+
+
+def test_catalog_path_exists():
+    import os
+
+    assert os.path.exists(LINT_PROFILES_PATH)
+
+
+def test_profiles_keyed_by_id():
+    by_id = lint_profiles_by_id()
+    for pid, profile in by_id.items():
+        assert pid == profile.id

--- a/tests/test_linting.py
+++ b/tests/test_linting.py
@@ -1,0 +1,64 @@
+"""Unit tests for gxformat2.linting primitives."""
+
+from gxformat2.linting import LEVEL_ERROR, LEVEL_WARN, LintContext, Linter, LintMessage
+
+
+class _FakeRule(Linter):
+    severity = "warning"
+    applies_to = ("native",)
+    profile = "structural"
+
+
+def test_lint_message_is_str():
+    msg = LintMessage("hello", level=LEVEL_ERROR, linter="R", json_pointer="/x")
+    assert isinstance(msg, str)
+    assert msg == "hello"
+    assert "ell" in msg
+    assert msg.level == LEVEL_ERROR
+    assert msg.linter == "R"
+    assert msg.json_pointer == "/x"
+
+
+def test_context_records_metadata():
+    ctx = LintContext()
+    ctx.error("bad {value}", value="x", linter=_FakeRule, json_pointer="/steps/0")
+    assert len(ctx.error_messages) == 1
+    msg = ctx.error_messages[0]
+    assert msg == "bad x"
+    assert msg.linter == "_FakeRule"
+    assert msg.json_pointer == "/steps/0"
+    assert msg.level == LEVEL_ERROR
+
+
+def test_child_composes_pointer():
+    ctx = LintContext()
+    child = ctx.child("steps").child(0)
+    child.warn("disconnected")
+    assert ctx.warn_messages[0].json_pointer == "/steps/0"
+    assert ctx.warn_messages[0].level == LEVEL_WARN
+
+
+def test_child_escapes_pointer_segment():
+    ctx = LintContext()
+    ctx.child("a/b~c").warn("x")
+    assert ctx.warn_messages[0].json_pointer == "/a~1b~0c"
+
+
+def test_explicit_pointer_overrides_context_pointer():
+    ctx = LintContext().child("steps")
+    ctx.error("oops", json_pointer="/elsewhere")
+    assert ctx.error_messages[0].json_pointer == "/elsewhere"
+
+
+def test_linter_accepts_string_name():
+    ctx = LintContext()
+    ctx.warn("hi", linter="DirectName")
+    assert ctx.warn_messages[0].linter == "DirectName"
+
+
+def test_unannotated_emission_has_empty_pointer_and_no_linter():
+    ctx = LintContext()
+    ctx.warn("generic")
+    msg = ctx.warn_messages[0]
+    assert msg.linter is None
+    assert msg.json_pointer == ""

--- a/tests/test_schema_rules_catalog.py
+++ b/tests/test_schema_rules_catalog.py
@@ -1,0 +1,107 @@
+"""Parametrized runner for the schema-rule catalog.
+
+Positive fixtures must pass both lax and strict validation. Negative fixtures
+must fail per the rule's declared scope and continue to pass in the opposite
+flavor (documenting that it IS scope-specific). Validators are selected from
+the fixture filename extension.
+"""
+
+import os
+from typing import List, Tuple
+
+import pytest
+from pydantic import ValidationError
+
+from gxformat2.examples import EXAMPLES_DIR, load, load_catalog
+from gxformat2.schema_rules import AppliesTo, load_schema_rules, Scope, SchemaRule
+from gxformat2.validators import validator_for_fixture
+
+RUNNER = "tests/test_schema_rules_catalog.py"
+RULES: List[SchemaRule] = load_schema_rules()
+
+
+def _fixture_applies_to(fixture: str) -> AppliesTo:
+    return AppliesTo.native if fixture.endswith(".ga") else AppliesTo.format2
+
+
+def _positive_cases() -> List[Tuple[str, str]]:
+    return [(rule.id, fx) for rule in RULES for fx in rule.tests.positive]
+
+
+def _negative_cases() -> List[Tuple[str, str, Scope]]:
+    return [(rule.id, fx, rule.scope) for rule in RULES for fx in rule.tests.negative]
+
+
+def _referenced_fixtures() -> set:
+    return {fx for rule in RULES for fx in rule.tests.positive + rule.tests.negative}
+
+
+@pytest.mark.parametrize("rule_id,fixture", _positive_cases())
+def test_positive_fixture_passes_lax_and_strict(rule_id, fixture):
+    wf = load(fixture)
+    validator_for_fixture(fixture, strict=False)(wf)
+    validator_for_fixture(fixture, strict=True)(wf)
+
+
+@pytest.mark.parametrize("rule_id,fixture,scope", _negative_cases())
+def test_negative_fixture_matches_scope(rule_id, fixture, scope):
+    wf = load(fixture)
+    if scope in (Scope.both, Scope.strict):
+        with pytest.raises(ValidationError):
+            validator_for_fixture(fixture, strict=True)(wf)
+    if scope == Scope.strict:
+        validator_for_fixture(fixture, strict=False)(wf)
+    if scope in (Scope.both, Scope.lax):
+        with pytest.raises(ValidationError):
+            validator_for_fixture(fixture, strict=False)(wf)
+    if scope == Scope.lax:
+        validator_for_fixture(fixture, strict=True)(wf)
+
+
+def test_schema_rules_have_fixtures():
+    """Every rule ships with at least one positive and one negative fixture."""
+    for rule in RULES:
+        assert rule.tests.positive, f"{rule.id}: empty positive fixture list"
+        assert rule.tests.negative, f"{rule.id}: empty negative fixture list"
+
+
+def test_fixture_format_matches_applies_to():
+    """A rule's fixtures must have extensions consistent with its `applies_to`."""
+    for rule in RULES:
+        for fx in rule.tests.positive + rule.tests.negative:
+            fmt = _fixture_applies_to(fx)
+            assert (
+                fmt in rule.applies_to
+            ), f"{rule.id}: fixture {fx} is {fmt.value} but rule applies_to={[a.value for a in rule.applies_to]}"
+
+
+def test_schema_rule_fixtures_exist_on_disk():
+    """Every fixture in schema_rules.yml resolves to a file."""
+    missing = []
+    for fx in _referenced_fixtures():
+        path_f2 = os.path.join(EXAMPLES_DIR, "format2", fx)
+        path_na = os.path.join(EXAMPLES_DIR, "native", fx)
+        if not (os.path.exists(path_f2) or os.path.exists(path_na)):
+            missing.append(fx)
+    assert not missing, f"schema_rules.yml fixtures not on disk: {missing}"
+
+
+def test_schema_rule_fixtures_in_catalog():
+    """Every fixture referenced by schema_rules.yml appears in examples catalog.yml."""
+    cataloged = {entry.name for entry in load_catalog()}
+    missing = _referenced_fixtures() - cataloged
+    assert not missing, f"schema_rules.yml references fixtures not in catalog.yml: {missing}"
+
+
+def test_schema_rule_fixtures_reference_runner():
+    """Catalog entries for schema-rule fixtures list this runner in their tests."""
+    referenced = _referenced_fixtures()
+    offenders = [entry.name for entry in load_catalog() if entry.name in referenced and RUNNER not in entry.tests]
+    assert not offenders, f"catalog entries missing {RUNNER}: {offenders}"
+
+
+def test_no_orphan_runner_tags_in_catalog():
+    """Catalog entries listing this runner must be referenced by schema_rules.yml."""
+    referenced = _referenced_fixtures()
+    orphaned = [entry.name for entry in load_catalog() if RUNNER in entry.tests and entry.name not in referenced]
+    assert not orphaned, f"catalog entries tag {RUNNER} but no schema rule references them: {orphaned}"


### PR DESCRIPTION
We were working on linting improvements so we could have a table that validates across Python CLI / TypeScript CLI / VS Code (very different way to markup these things) and we realized that we probably broke Planemo with a recent change. I think I want to get this backward compat shim in place and publish it so that Planemo doesn't remain broken. 