### PR TITLE
Source venv when resolving VERSION in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ UPSTREAM?=galaxyproject
 SOURCE_DIR?=gxformat2
 BUILD_SCRIPTS_DIR=scripts
 DEV_RELEASE?=0
-VERSION?=$(shell DEV_RELEASE=$(DEV_RELEASE) python $(BUILD_SCRIPTS_DIR)/print_version_for_release.py $(SOURCE_DIR) $(DEV_RELEASE))
+VERSION?=$(shell $(IN_VENV) DEV_RELEASE=$(DEV_RELEASE) python $(BUILD_SCRIPTS_DIR)/print_version_for_release.py $(SOURCE_DIR) $(DEV_RELEASE))
 DOC_URL?=https://gxformat2.readthedocs.org
 PROJECT_URL?=https://github.com/jmchilton/gxformat2
 PROJECT_NAME?=gxformat2


### PR DESCRIPTION
## Summary
- `make release` failed on macOS because the `VERSION?=$(shell ... python ...)` line invoked bare `python`, which isn't on PATH (only `python3` is).
- Prepending `$(IN_VENV)` sources `.venv/bin/activate` so `python` resolves inside the dev venv that `make setup-venv` already creates.
- Also reorders `DEV_RELEASE=...` to sit after the `if ... fi;` block so the env-var prefix applies to the `python` invocation instead of clashing with the compound statement.

## Test plan
- [x] `make -n commit-version` shows `DEV_RELEASE=0 python scripts/commit_version.py ...` with venv sourced first and VERSION resolved correctly
- [x] `make release VERSION=0.25.0` succeeded as a workaround during 0.25.0 release; this fix removes the need for the explicit override