### PR TITLE
Declarative YAML test coverage for gxformat2.mermaid

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,7 +9,10 @@ History
 0.27.0.dev0
 ---------------------
 
-    
+* Declarative YAML-driven test coverage for ``gxformat2.mermaid``; fix
+  ``_input_type_str`` to accept string input types (previous ``.value``
+  attribute access crashed on real workflows).
+
 
 ---------------------
 0.26.0 (2026-04-17)

--- a/gxformat2/examples/expectations/mermaid.yml
+++ b/gxformat2/examples/expectations/mermaid.yml
@@ -86,7 +86,8 @@ test_frame_comments_not_emitted_without_flag:
   operation: workflow_to_mermaid
   assertions:
     - path: []
-      value_matches: '(?s)\A(?!.*subgraph).*\Z'
+      # Use [\s\S] instead of (?s) + . so both Python re and JS RegExp accept it.
+      value_matches: '^(?![\s\S]*subgraph)'
 
 test_frame_comments_rendered_as_subgraph:
   fixture: synthetic-comments-dict.gxwf.yml

--- a/gxformat2/examples/expectations/mermaid.yml
+++ b/gxformat2/examples/expectations/mermaid.yml
@@ -1,0 +1,130 @@
+# Mermaid flowchart generation from Galaxy workflows.
+# workflow_to_mermaid returns a single string; the _lines variants split on "\n"
+# so per-line assertions can use list-mode helpers ($length, value_any_contains).
+
+test_simple_graph_header:
+  fixture: synthetic-graph-simple.gxwf.yml
+  operation: workflow_to_mermaid_lines
+  assertions:
+    - path: [0]
+      value: "graph LR"
+
+test_simple_graph_data_input_shape:
+  fixture: synthetic-graph-simple.gxwf.yml
+  operation: workflow_to_mermaid_lines
+  assertions:
+    - path: []
+      value_any_contains: 'input_0>"the_input<br/><i>data</i>"]'
+
+test_simple_graph_tool_step_shape:
+  fixture: synthetic-graph-simple.gxwf.yml
+  operation: workflow_to_mermaid_lines
+  assertions:
+    - path: []
+      value_any_contains: 'step_0["cat"]'
+
+test_simple_graph_edge:
+  fixture: synthetic-graph-simple.gxwf.yml
+  operation: workflow_to_mermaid_lines
+  assertions:
+    - path: []
+      value_any_contains: "input_0 --> step_0"
+
+test_simple_graph_exact:
+  fixture: synthetic-graph-simple.gxwf.yml
+  operation: workflow_to_mermaid
+  assertions:
+    - path: []
+      value: |-
+        graph LR
+            input_0>"the_input<br/><i>data</i>"]
+            step_0["cat"]
+            input_0 --> step_0
+
+test_multi_data_inputs_distinct_ids:
+  fixture: synthetic-multi-data-input.gxwf.yml
+  operation: workflow_to_mermaid_lines
+  assertions:
+    - path: []
+      value_any_contains: 'input_0>"optional<br/><i>data</i>"]'
+    - path: []
+      value_any_contains: 'input_1>"required<br/><i>data</i>"]'
+    - path: []
+      value_any_contains: "input_1 --> step_0"
+    - path: []
+      value_any_contains: "input_0 --> step_0"
+
+test_int_input_renders:
+  fixture: synthetic-int-input.gxwf.yml
+  operation: workflow_to_mermaid_lines
+  assertions:
+    - path: []
+      value_any_contains: '"num_lines<br/><i>int</i>"'
+    - path: []
+      value_any_contains: '"input_d<br/><i>data</i>"'
+
+test_subworkflow_step_uses_double_bracket_shape:
+  fixture: synthetic-graph-with-subworkflow.gxwf.yml
+  operation: workflow_to_mermaid_lines
+  assertions:
+    - path: []
+      value_any_contains: 'step_1[["nested_workflow"]]'
+    - path: []
+      value_any_contains: 'step_0["first_cat"]'
+    - path: []
+      value_any_contains: "step_0 --> step_1"
+
+test_frame_comments_ignored_by_default:
+  fixture: synthetic-comments-dict.gxwf.yml
+  operation: workflow_to_mermaid
+  assertions:
+    - path: []
+      value_contains: 'step_0["cat"]'
+
+test_frame_comments_not_emitted_without_flag:
+  fixture: synthetic-comments-dict.gxwf.yml
+  operation: workflow_to_mermaid
+  assertions:
+    - path: []
+      value_matches: '(?s)\A(?!.*subgraph).*\Z'
+
+test_frame_comments_rendered_as_subgraph:
+  fixture: synthetic-comments-dict.gxwf.yml
+  operation: workflow_to_mermaid_with_comments_lines
+  assertions:
+    - path: []
+      value_any_contains: 'subgraph sub_0 ["Preprocessing"]'
+    - path: []
+      value_any_contains: 'step_0["cat"]'
+    - path: []
+      value_any_contains: "end"
+    - path: []
+      value_any_contains: "input_0 --> step_0"
+
+test_basic_workflow_single_edge:
+  fixture: synthetic-basic.gxwf.yml
+  operation: workflow_to_mermaid_lines
+  assertions:
+    - path: [0]
+      value: "graph LR"
+    - path: []
+      value_any_contains: 'input_0>"the_input<br/><i>data</i>"]'
+    - path: []
+      value_any_contains: 'step_0["cat"]'
+    - path: []
+      value_any_contains: "input_0 --> step_0"
+
+test_real_sars_cov2_shape:
+  fixture: real-sars-cov2-variant-calling.ga
+  operation: workflow_to_mermaid_lines
+  assertions:
+    - path: [0]
+      value: "graph LR"
+    - path: []
+      value_any_contains: 'input_0>"Accessions file<br/><i>data</i>"]'
+    - path: []
+      value_any_contains: 'step_8["SnpSift summary table"]'
+    - path: []
+      value_any_contains: "input_0 --> step_0"
+    - path: []
+      value_any_contains: "step_6 --> step_8"

--- a/gxformat2/mermaid/_builder.py
+++ b/gxformat2/mermaid/_builder.py
@@ -46,10 +46,10 @@ def _input_type_str(inp: BaseInputParameter) -> str:
     if type_ is None:
         return "input"
     if isinstance(type_, list):
-        if type_:
-            return type_[0].value
-        return "input"
-    return type_.value
+        if not type_:
+            return "input"
+        type_ = type_[0]
+    return getattr(type_, "value", type_)
 
 
 def _node_line(node_id: str, label: str, shape: tuple[str, str]) -> str:

--- a/tests/test_interop_tests.py
+++ b/tests/test_interop_tests.py
@@ -14,6 +14,7 @@ from gxformat2.lint import lint_best_practices_ga as _lint_bp_ga_impl
 from gxformat2.lint import lint_format2 as _lint_format2_impl
 from gxformat2.lint import lint_ga as _lint_ga_impl
 from gxformat2.linting import LintContext
+from gxformat2.mermaid import workflow_to_mermaid as _mermaid_impl
 from gxformat2.normalized import (
     ensure_format2,
     ensure_native,
@@ -99,6 +100,18 @@ def _lint_best_practices_native(wf_dict):
     }
 
 
+def _workflow_to_mermaid(wf_dict):
+    return _mermaid_impl(wf_dict)
+
+
+def _workflow_to_mermaid_lines(wf_dict):
+    return _mermaid_impl(wf_dict).split("\n")
+
+
+def _workflow_to_mermaid_with_comments_lines(wf_dict):
+    return _mermaid_impl(wf_dict, comments=True).split("\n")
+
+
 EXPECTATIONS_DIR = os.path.join(EXAMPLES_DIR, "expectations")
 OPERATIONS: Dict[str, Callable[..., Any]] = {
     "normalized_format2": normalized_format2,
@@ -117,6 +130,9 @@ OPERATIONS: Dict[str, Callable[..., Any]] = {
     "lint_native": _lint_native,
     "lint_best_practices_format2": _lint_best_practices_format2,
     "lint_best_practices_native": _lint_best_practices_native,
+    "workflow_to_mermaid": _workflow_to_mermaid,
+    "workflow_to_mermaid_lines": _workflow_to_mermaid_lines,
+    "workflow_to_mermaid_with_comments_lines": _workflow_to_mermaid_with_comments_lines,
 }
 
 suite = DeclarativeTestSuite(

--- a/tests/test_mermaid.py
+++ b/tests/test_mermaid.py
@@ -1,0 +1,62 @@
+"""CLI smoke tests for gxformat2.mermaid.
+
+Behavioral coverage of workflow_to_mermaid lives in declarative YAML
+(gxformat2/examples/expectations/mermaid.yml) and runs from
+test_interop_tests.py — keep this file for things that aren't a pure
+function of (workflow dict) -> result.
+"""
+
+import os
+import tempfile
+
+from gxformat2.mermaid import main, to_mermaid
+
+from ._helpers import example_path
+
+EXAMPLE_PATH = example_path("real-hacked-unicycler-assembly-extra-annotations.ga")
+
+
+def test_cli_writes_mmd_raw():
+    with tempfile.NamedTemporaryFile(suffix=".mmd", delete=False) as out:
+        out_path = out.name
+    try:
+        main([EXAMPLE_PATH, out_path])
+        with open(out_path) as f:
+            content = f.read()
+        assert content.startswith("graph LR\n")
+        assert "```" not in content
+    finally:
+        os.unlink(out_path)
+
+
+def test_cli_wraps_md_in_fence():
+    with tempfile.NamedTemporaryFile(suffix=".md", delete=False) as out:
+        out_path = out.name
+    try:
+        main([EXAMPLE_PATH, out_path])
+        with open(out_path) as f:
+            content = f.read()
+        assert content.startswith("```mermaid\n")
+        assert content.rstrip().endswith("```")
+        assert "graph LR" in content
+    finally:
+        os.unlink(out_path)
+
+
+def test_cli_stdout(capsys):
+    main([EXAMPLE_PATH])
+    captured = capsys.readouterr()
+    assert captured.out.startswith("graph LR\n")
+
+
+def test_cli_comments_flag(capsys):
+    # Workflow without frame comments → flag is a no-op (no subgraph).
+    main([EXAMPLE_PATH, "--comments"])
+    captured = capsys.readouterr()
+    assert captured.out.startswith("graph LR\n")
+
+
+def test_to_mermaid_stdout_passthrough(capsys):
+    to_mermaid(EXAMPLE_PATH)
+    captured = capsys.readouterr()
+    assert "graph LR" in captured.out


### PR DESCRIPTION
## Summary

- Add ``gxformat2/examples/expectations/mermaid.yml`` with 13 declarative cases covering mermaid builder output (header, data/subworkflow shapes, int input rendering, edges, frame-comment subgraph toggle, real-workflow smoke). Consumed by the existing ``DeclarativeTestSuite`` harness so downstream ports (TypeScript ``galaxy-tool-util``) can sync and reuse them.
- Register ``workflow_to_mermaid``, ``workflow_to_mermaid_lines``, ``workflow_to_mermaid_with_comments_lines`` in ``tests/test_interop_tests.py`` OPERATIONS. ``_lines`` variants split on ``\n`` so list-mode assertions (``$length``, ``value_any_contains``) apply per line.
- Fixtures reuse existing ``synthetic-*`` / ``real-*`` files — no new workflow fixtures.
- Thin ``tests/test_mermaid.py`` retained for CLI-only smoke checks (stdout, ``.mmd`` raw vs ``.md`` fenced wrapping, ``--comments`` flag).
- Fix latent bug in ``_input_type_str``: ``inp.type_`` is a ``str`` for normalized inputs, not an enum — prior code crashed with ``AttributeError: 'str' object has no attribute 'value'`` on every real workflow. Surfaced by first test-suite run.

## Test plan

- [x] ``pytest tests/`` — 631 passed, 8 skipped (no regressions)
- [x] Mermaid subset: 14 new cases + 5 CLI smoke — all green
- [ ] TypeScript port consumes ``mermaid.yml`` via ``make sync-workflow-expectations``