### PR TITLE
Bump cytoscape.html CDN deps to current versions

### DIFF
--- a/gxformat2/cytoscape/cytoscape.html
+++ b/gxformat2/cytoscape/cytoscape.html
@@ -4,11 +4,11 @@
 
 <head>
     <title>Galaxy Workflow</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/cytoscape/3.9.4/cytoscape.min.js"></script>
-    <script src="https://unpkg.com/popper.js@1.14.7/dist/umd/popper.js"></script>
-    <script src="https://unpkg.com/tippy.js@4.0.1/umd/index.all.min.js"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tippy.js@4.0.1/index.css" />
-    <script src="https://cdn.jsdelivr.net/npm/cytoscape-popper@1.0.4/cytoscape-popper.min.js"></script>
+    <script src="https://unpkg.com/cytoscape@3.33.2/dist/cytoscape.min.js"></script>
+    <script src="https://unpkg.com/@popperjs/core@2.11.8/dist/umd/popper.min.js"></script>
+    <script src="https://unpkg.com/cytoscape-popper@2.0.0/cytoscape-popper.js"></script>
+    <script src="https://unpkg.com/tippy.js@6.3.7/dist/tippy.umd.min.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/tippy.js@6.3.7/dist/tippy.css" />
     <script>
 document.addEventListener("DOMContentLoaded", function() {
     var cy = cytoscape({
@@ -52,8 +52,10 @@ document.addEventListener("DOMContentLoaded", function() {
 
   function makePopper(ele) {
     let ref = ele.popperRef(); // used only for positioning
+    let dummyDomEle = document.createElement('div');
 
-    ele.tippy = new tippy(ref, { // tippy options:
+    ele.tippy = tippy(dummyDomEle, { // tippy options:
+      getReferenceClientRect: ref.getBoundingClientRect.bind(ref),
       content: function() {
         let content = document.createElement('div');
 
@@ -89,7 +91,8 @@ document.addEventListener("DOMContentLoaded", function() {
       delay: [0,1000],
       interactive: true,
       placement: 'bottom',
-      trigger: 'manual' // probably want manual mode
+      trigger: 'manual', // probably want manual mode
+      appendTo: document.body
     });
   }
 
@@ -118,7 +121,7 @@ document.addEventListener("DOMContentLoaded", function() {
         top: 0px;
         left: 0px;
     }
-    a { 
+    a {
         color: #d0bb46
     }
 </style>


### PR DESCRIPTION
## Summary

Coordinated upgrade of the standalone Cytoscape viewer template (`gxformat2/cytoscape/cytoscape.html`):

- cytoscape **3.9.4 → 3.33.2** (cdnjs lags 3.33.x, switched to unpkg)
- popper.js **1.14.7 → @popperjs/core 2.11.8**
- cytoscape-popper **1.0.4 → 2.0.0** (auto-registers under cytoscape's UMD; explicit `cytoscape.use()` no longer needed)
- tippy.js **4.0.1 → 6.3.7**

## Code changes

Tippy 6 stopped accepting virtual elements as the first argument (a tippy 5 break). Switched to the documented dummy-div + `getReferenceClientRect` pattern that cytoscape-popper@2 + tippy@6 expects:

```js
let ref = ele.popperRef();
let dummyDomEle = document.createElement('div');
ele.tippy = tippy(dummyDomEle, {
  getReferenceClientRect: ref.getBoundingClientRect.bind(ref),
  ...
});
```

Also dropped `new` (tippy 5+ is a factory) and added `appendTo: document.body` so the popper renders outside the cytoscape container.

## Test plan

- [x] `pytest tests/test_cytoscape.py` — 5 passed
- [x] Browser-verified on `synthetic-graph-with-subworkflow.gxwf.yml`: 3 nodes / 2 edges render, hover triggers `tippy.show()` producing `[data-tippy-root]` in DOM, console clean (0 errors / 0 warnings)
- [ ] Reviewer eyeball check on a real workflow if desired