### PR TITLE
cytoscape: --layout flag with shared topological algorithm

### DIFF
--- a/gxformat2/cytoscape/__init__.py
+++ b/gxformat2/cytoscape/__init__.py
@@ -2,26 +2,42 @@
 
 from ._builder import cytoscape_elements
 from ._cli import main, to_cytoscape
+from ._layout import (
+    bakes_coordinates,
+    COL_STRIDE,
+    is_layout_name,
+    LAYOUT_NAMES,
+    ROW_STRIDE,
+    topological_positions,
+)
 from ._render import CYTOSCAPE_JS_TEMPLATE, render_html
 from .models import (
     CytoscapeEdge,
     CytoscapeEdgeData,
     CytoscapeElements,
+    CytoscapeLayout,
     CytoscapeNode,
     CytoscapeNodeData,
     CytoscapePosition,
 )
 
 __all__ = (
+    "COL_STRIDE",
     "CYTOSCAPE_JS_TEMPLATE",
     "CytoscapeEdge",
     "CytoscapeEdgeData",
     "CytoscapeElements",
+    "CytoscapeLayout",
     "CytoscapeNode",
     "CytoscapeNodeData",
     "CytoscapePosition",
+    "LAYOUT_NAMES",
+    "ROW_STRIDE",
+    "bakes_coordinates",
     "cytoscape_elements",
+    "is_layout_name",
     "main",
     "render_html",
     "to_cytoscape",
+    "topological_positions",
 )

--- a/gxformat2/cytoscape/_builder.py
+++ b/gxformat2/cytoscape/_builder.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from gxformat2._labels import Labels
 from gxformat2.normalized import ensure_format2, NormalizedFormat2, NormalizedWorkflowStep
 from gxformat2.schema.gxformat2 import BaseInputParameter, GalaxyType, GalaxyWorkflow
 
@@ -125,7 +126,8 @@ def _step_node(step: NormalizedWorkflowStep, order_index: int) -> CytoscapeNode:
     if tool_id and tool_id.startswith(MAIN_TS_PREFIX):
         tool_id = tool_id[len(MAIN_TS_PREFIX) :]
 
-    label = step.label or step.id or (f"tool:{tool_id}" if tool_id else str(order_index))
+    display_id = step.id if step.id and not Labels.is_unlabeled(step.id) else None
+    label = step.label or display_id or (f"tool:{tool_id}" if tool_id else str(order_index))
 
     repo_link = None
     if step.tool_shed_repository:

--- a/gxformat2/cytoscape/_builder.py
+++ b/gxformat2/cytoscape/_builder.py
@@ -8,10 +8,12 @@ from typing import Any
 from gxformat2.normalized import ensure_format2, NormalizedFormat2, NormalizedWorkflowStep
 from gxformat2.schema.gxformat2 import BaseInputParameter, GalaxyType, GalaxyWorkflow
 
+from ._layout import bakes_coordinates, is_layout_name, topological_positions
 from .models import (
     CytoscapeEdge,
     CytoscapeEdgeData,
     CytoscapeElements,
+    CytoscapeLayout,
     CytoscapeNode,
     CytoscapeNodeData,
     CytoscapePosition,
@@ -22,12 +24,22 @@ MAIN_TS_PREFIX = "toolshed.g2.bx.psu.edu/repos/"
 
 def cytoscape_elements(
     workflow: dict[str, Any] | str | Path | GalaxyWorkflow | NormalizedFormat2,
+    *,
+    layout: str = "preset",
 ) -> CytoscapeElements:
     """Build Cytoscape visualization elements from a Galaxy workflow.
 
     Accepts anything ``normalized_format2()`` supports, plus an already
     normalized ``NormalizedFormat2`` instance.
+
+    ``layout`` selects the placement strategy (default ``preset``); see
+    ``_layout.py`` and the cross-language spec for details.
     """
+    if not is_layout_name(layout):
+        raise ValueError(
+            f'Unknown layout "{layout}". Valid values: ' "preset, topological, dagre, breadthfirst, grid, cose, random."
+        )
+
     if isinstance(workflow, NormalizedFormat2):
         nf2 = workflow
     else:
@@ -44,7 +56,25 @@ def cytoscape_elements(
         nodes.append(_step_node(step, i + inputs_offset))
         edges.extend(_step_edges(step, nf2))
 
-    return CytoscapeElements(nodes=nodes, edges=edges)
+    elements = CytoscapeElements(nodes=nodes, edges=edges)
+
+    if layout == "preset":
+        return elements
+
+    if bakes_coordinates(layout):
+        # Currently only ``topological`` reaches here.
+        positions = topological_positions(elements)
+        for node in nodes:
+            p = positions.get(node.data.id)
+            if p is not None:
+                node.position = p
+    else:
+        # Hint-only layout: drop coordinates; the runtime renderer places nodes.
+        for node in nodes:
+            node.position = None
+
+    elements.layout = CytoscapeLayout(name=layout)
+    return elements
 
 
 def _fallback_position(order_index: int) -> CytoscapePosition:

--- a/gxformat2/cytoscape/_cli.py
+++ b/gxformat2/cytoscape/_cli.py
@@ -5,6 +5,7 @@ import os
 import sys
 
 from ._builder import cytoscape_elements
+from ._layout import LAYOUT_NAMES
 from ._render import render_html
 
 SCRIPT_DESCRIPTION = """
@@ -19,20 +20,23 @@ Cytoscape.
 """
 
 
-def to_cytoscape(workflow_path: str, output_path=None):
+def to_cytoscape(workflow_path: str, output_path=None, layout: str = "preset"):
     """Produce cytoscape output for supplied workflow path."""
     if output_path is None:
         output_path, _ = os.path.splitext(workflow_path)
         output_path += ".html"
 
-    elements = cytoscape_elements(workflow_path)
+    elements = cytoscape_elements(workflow_path, layout=layout)
 
     if output_path.endswith(".html"):
         with open(output_path, "w") as f:
-            f.write(render_html(elements))
+            f.write(render_html(elements, layout=layout))
     else:
+        # Bare flat list for ``preset`` (back-compat); wrapped {elements, layout}
+        # otherwise so the layout hint travels with the JSON.
+        payload = elements.to_list() if layout == "preset" else elements.to_dict()
         with open(output_path, "w") as f:
-            json.dump(elements.to_list(), f)
+            json.dump(payload, f)
 
 
 def main(argv=None):
@@ -41,7 +45,7 @@ def main(argv=None):
         argv = sys.argv[1:]
 
     args = _parser().parse_args(argv)
-    to_cytoscape(args.input_path, args.output_path)
+    to_cytoscape(args.input_path, args.output_path, layout=args.layout)
 
 
 def _parser():
@@ -50,4 +54,14 @@ def _parser():
     parser = argparse.ArgumentParser(description=SCRIPT_DESCRIPTION)
     parser.add_argument("input_path", metavar="INPUT", type=str, help="input workflow path (.ga/gxwf.yml)")
     parser.add_argument("output_path", metavar="OUTPUT", type=str, nargs="?", help="output viz path (.json/.html)")
+    parser.add_argument(
+        "--layout",
+        type=str,
+        default="preset",
+        choices=list(LAYOUT_NAMES),
+        help=(
+            "Layout strategy: preset (default; honors workflow positions), "
+            "topological (computed leveled layout), dagre, breadthfirst, grid, cose, random"
+        ),
+    )
     return parser

--- a/gxformat2/cytoscape/_layout.py
+++ b/gxformat2/cytoscape/_layout.py
@@ -32,6 +32,7 @@ LAYOUT_NAMES: tuple[str, ...] = get_args(LayoutName)
 
 
 def is_layout_name(value: str) -> bool:
+    """Return True if ``value`` is one of the supported Cytoscape layout names."""
     return value in LAYOUT_NAMES
 
 

--- a/gxformat2/cytoscape/_layout.py
+++ b/gxformat2/cytoscape/_layout.py
@@ -1,0 +1,117 @@
+"""Cross-language topological layout for Cytoscape elements.
+
+Mirror of the TypeScript port at
+``galaxy-tool-util-ts/packages/schema/src/workflow/cytoscape-layout.ts``.
+
+Both implementations MUST produce byte-identical (x, y) coordinates for a
+given input. The normative spec lives in the galaxy-tool-util-ts repo at
+``docs/architecture/cytoscape-layout.md``. Any change here is a breaking
+visual diff and must land in lockstep with that file.
+"""
+
+from __future__ import annotations
+
+from typing import get_args, Literal
+
+from .models import CytoscapeElements, CytoscapePosition
+
+COL_STRIDE = 220
+ROW_STRIDE = 100
+
+LayoutName = Literal[
+    "preset",
+    "topological",
+    "dagre",
+    "breadthfirst",
+    "grid",
+    "cose",
+    "random",
+]
+
+LAYOUT_NAMES: tuple[str, ...] = get_args(LayoutName)
+
+
+def is_layout_name(value: str) -> bool:
+    return value in LAYOUT_NAMES
+
+
+def bakes_coordinates(layout: str) -> bool:
+    """Layouts that bake coordinates into ``data.position``.
+
+    All other layouts are hint-only and rely on the runtime renderer.
+    """
+    return layout in ("preset", "topological")
+
+
+def topological_positions(elements: CytoscapeElements) -> dict[str, CytoscapePosition]:
+    """Compute positions per the topological layering spec.
+
+    Returns a mapping keyed by node ``data.id``.
+    """
+    nodes = elements.nodes
+    node_ids = [n.data.id for n in nodes]
+    index_by_id = {node_id: i for i, node_id in enumerate(node_ids)}
+
+    incoming: dict[str, list[str]] = {node_id: [] for node_id in node_ids}
+    for edge in elements.edges:
+        source = edge.data.source
+        target = edge.data.target
+        if source not in index_by_id or target not in index_by_id:
+            continue
+        incoming[target].append(source)
+
+    in_degree: dict[str, int] = {node_id: len(srcs) for node_id, srcs in incoming.items()}
+
+    dependents: dict[str, list[str]] = {node_id: [] for node_id in node_ids}
+    for target, sources in incoming.items():
+        for s in sources:
+            dependents[s].append(target)
+
+    column: dict[str, int] = {}
+    visited: set[str] = set()
+
+    # Kahn topo sort, declaration-index tie break.
+    queue: list[str] = [node_id for node_id in node_ids if in_degree[node_id] == 0]
+    queue.sort(key=lambda nid: index_by_id[nid])
+
+    while queue:
+        # Pop lowest declaration index.
+        best = 0
+        for i in range(1, len(queue)):
+            if index_by_id[queue[i]] < index_by_id[queue[best]]:
+                best = i
+        node_id = queue.pop(best)
+        visited.add(node_id)
+
+        sources = incoming[node_id]
+        if not sources:
+            column[node_id] = 0
+        else:
+            max_col = 0
+            for s in sources:
+                c = column.get(s)
+                if c is not None and c + 1 > max_col:
+                    max_col = c + 1
+            column[node_id] = max_col
+
+        for dep in dependents[node_id]:
+            in_degree[dep] -= 1
+            if in_degree[dep] == 0:
+                queue.append(dep)
+
+    # Cycle fallback: any unvisited node gets column = declaration index.
+    for node_id in node_ids:
+        if node_id not in visited:
+            column[node_id] = index_by_id[node_id]
+
+    # Row assignment: per column, declaration order.
+    rows_by_column: dict[int, list[str]] = {}
+    for node_id in node_ids:
+        c = column[node_id]
+        rows_by_column.setdefault(c, []).append(node_id)
+
+    positions: dict[str, CytoscapePosition] = {}
+    for c, ids in rows_by_column.items():
+        for row, node_id in enumerate(ids):
+            positions[node_id] = CytoscapePosition(x=c * COL_STRIDE, y=row * ROW_STRIDE)
+    return positions

--- a/gxformat2/cytoscape/_render.py
+++ b/gxformat2/cytoscape/_render.py
@@ -9,7 +9,7 @@ from .models import CytoscapeElements
 CYTOSCAPE_JS_TEMPLATE = os.path.join(os.path.dirname(__file__), "cytoscape.html")
 
 
-def render_html(elements: CytoscapeElements) -> str:
+def render_html(elements: CytoscapeElements, layout: str = "preset") -> str:
     """Return a standalone HTML page visualizing the workflow with Cytoscape.js.
 
     The returned string is a complete HTML document suitable for writing
@@ -17,4 +17,7 @@ def render_html(elements: CytoscapeElements) -> str:
     """
     with open(CYTOSCAPE_JS_TEMPLATE) as f:
         template = f.read()
-    return string.Template(template).safe_substitute(elements=json.dumps(elements.to_list()))
+    return string.Template(template).safe_substitute(
+        elements=json.dumps(elements.to_list()),
+        layout=json.dumps(layout),
+    )

--- a/gxformat2/cytoscape/cytoscape.html
+++ b/gxformat2/cytoscape/cytoscape.html
@@ -5,18 +5,36 @@
 <head>
     <title>Galaxy Workflow</title>
     <script src="https://unpkg.com/cytoscape@3.33.2/dist/cytoscape.min.js"></script>
+    <script src="https://unpkg.com/dagre@0.8.5/dist/dagre.min.js"></script>
+    <script src="https://unpkg.com/cytoscape-dagre@2.5.0/cytoscape-dagre.js"></script>
     <script src="https://unpkg.com/@popperjs/core@2.11.8/dist/umd/popper.min.js"></script>
     <script src="https://unpkg.com/cytoscape-popper@2.0.0/cytoscape-popper.js"></script>
     <script src="https://unpkg.com/tippy.js@6.3.7/dist/tippy.umd.min.js"></script>
     <link rel="stylesheet" href="https://unpkg.com/tippy.js@6.3.7/dist/tippy.css" />
     <script>
 document.addEventListener("DOMContentLoaded", function() {
+    var requestedLayout = $layout;
+    var dagreReady = (typeof cytoscapeDagre !== 'undefined');
+    if (dagreReady && cytoscape.use) {
+        try { cytoscape.use(cytoscapeDagre); } catch (e) { /* already registered */ }
+    }
+    var layoutConfig = (function(name) {
+        if (name === 'dagre') {
+            return dagreReady
+                ? { name: 'dagre', rankDir: 'LR', nodeSep: 40, rankSep: 80 }
+                : { name: 'preset' };
+        }
+        if (name === 'breadthfirst') return { name: 'breadthfirst', directed: true, spacingFactor: 1.2 };
+        if (name === 'grid') return { name: 'grid' };
+        if (name === 'cose') return { name: 'cose' };
+        if (name === 'random') return { name: 'random' };
+        if (name === 'topological') return { name: 'preset' };
+        return { name: 'preset' };
+    })(requestedLayout);
     var cy = cytoscape({
         container: document.getElementById('cy'),
         elements: $elements,
-        layout: {
-            name: 'preset'
-        },
+        layout: layoutConfig,
         // so we can see the ids
         style: [
             {
@@ -45,6 +63,27 @@ document.addEventListener("DOMContentLoaded", function() {
                 style: {
                     shape: 'round-rectangle',
                     'background-color': '#2c3143'
+                }
+            },
+            {
+                selector: 'edge.mapover_1',
+                style: { width: 4, 'line-color': '#5a8' }
+            },
+            {
+                selector: 'edge.mapover_2',
+                style: { width: 6, 'line-color': '#5a8' }
+            },
+            {
+                selector: 'edge.mapover_3',
+                style: { width: 8, 'line-color': '#5a8' }
+            },
+            {
+                selector: 'edge.reduction',
+                style: {
+                    'line-style': 'dashed',
+                    'line-color': '#a55',
+                    'target-arrow-shape': 'tee',
+                    'target-arrow-color': '#a55'
                 }
             }
         ]
@@ -82,6 +121,14 @@ document.addEventListener("DOMContentLoaded", function() {
                 innerHTML += "Output named " + output + " connects to " + input;
             } else {
                 innerHTML += "Connected to input " + input;
+            }
+            let mapDepth = ele.data("map_depth");
+            if (mapDepth) {
+                let mapping = ele.data("mapping");
+                innerHTML += "<p><i>Map depth:</i> " + mapDepth + (mapping ? " (" + mapping + ")" : "") + "</p>";
+            }
+            if (ele.data("reduction")) {
+                innerHTML += "<p><i>Reduction:</i> list → multi-data</p>";
             }
         }
         content.innerHTML = innerHTML;

--- a/gxformat2/cytoscape/models.py
+++ b/gxformat2/cytoscape/models.py
@@ -41,7 +41,10 @@ class CytoscapeNode(BaseModel):
     group: Literal["nodes"] = "nodes"
     data: CytoscapeNodeData
     classes: list[str] = Field(default_factory=list)
-    position: CytoscapePosition = Field(default_factory=CytoscapePosition)
+    # Present for ``preset`` and ``topological`` layouts; omitted for hint-only
+    # layouts (``dagre``, ``breadthfirst``, ``grid``, ``cose``, ``random``) so
+    # the runtime renderer is responsible for placement.
+    position: CytoscapePosition | None = Field(default=None)
 
 
 class CytoscapeEdge(BaseModel):
@@ -51,17 +54,43 @@ class CytoscapeEdge(BaseModel):
     data: CytoscapeEdgeData
 
 
+class CytoscapeLayout(BaseModel):
+    """Layout hint emitted on non-default layouts."""
+
+    name: str
+
+
 class CytoscapeElements(BaseModel):
     """Complete set of Cytoscape.js elements for a workflow visualization."""
 
     nodes: list[CytoscapeNode] = Field(default_factory=list)
     edges: list[CytoscapeEdge] = Field(default_factory=list)
+    # Present only when the builder was invoked with a non-``preset`` layout.
+    # Carried out-of-band so ``to_list()`` keeps the flat-list contract.
+    layout: CytoscapeLayout | None = Field(default=None)
 
     def to_list(self) -> list[dict]:
         """Serialize to the flat list-of-dicts format Cytoscape.js expects."""
         elements: list[dict] = []
         for node in self.nodes:
-            elements.append(node.model_dump())
+            # Drop ``position`` only when it's None (hint-only layouts). We
+            # avoid ``exclude_none`` because it would also strip nested nulls
+            # like ``tool_id: null``, breaking byte-parity for the default flow.
+            if node.position is None:
+                elements.append(node.model_dump(exclude={"position"}))
+            else:
+                elements.append(node.model_dump())
         for edge in self.edges:
             elements.append(edge.model_dump())
         return elements
+
+    def to_dict(self) -> dict:
+        """Serialize as ``{"elements": [...], "layout": {...}}`` wrapper.
+
+        Used by the CLI when ``--layout`` is non-default so the layout hint
+        travels alongside the elements.
+        """
+        result: dict = {"elements": self.to_list()}
+        if self.layout is not None:
+            result["layout"] = self.layout.model_dump()
+        return result

--- a/gxformat2/mermaid/_builder.py
+++ b/gxformat2/mermaid/_builder.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from gxformat2._labels import Labels
 from gxformat2.normalized import ensure_format2, NormalizedFormat2
 from gxformat2.schema.gxformat2 import BaseInputParameter, FrameComment, GalaxyWorkflow
 
@@ -101,7 +102,8 @@ def workflow_to_mermaid(
         if tool_id and tool_id.startswith(MAIN_TS_PREFIX):
             tool_id = tool_id[len(MAIN_TS_PREFIX) :]
 
-        label = _sanitize_label(step.label or step.id or (f"tool:{tool_id}" if tool_id else str(i)))
+        display_id = step.id if step.id and not Labels.is_unlabeled(step.id) else None
+        label = _sanitize_label(step.label or display_id or (f"tool:{tool_id}" if tool_id else str(i)))
         step_type = step.type_.value if step.type_ else "tool"
         step_lines[step_label] = _node_line(node_id, label, STEP_TYPE_SHAPES.get(step_type, SHAPE_TOOL))
 

--- a/tests/test_cytoscape_layout.py
+++ b/tests/test_cytoscape_layout.py
@@ -1,0 +1,105 @@
+"""Cross-language parity tests for the topological layout.
+
+Mirrors galaxy-tool-util-ts's
+``packages/schema/test/cytoscape-layout.test.ts``. Coordinates are hard-coded
+and MUST be byte-identical with the TS implementation.
+"""
+
+from gxformat2.cytoscape._layout import (
+    COL_STRIDE,
+    ROW_STRIDE,
+    topological_positions,
+)
+from gxformat2.cytoscape.models import (
+    CytoscapeEdge,
+    CytoscapeEdgeData,
+    CytoscapeElements,
+    CytoscapeNode,
+    CytoscapeNodeData,
+)
+
+
+def _n(node_id: str) -> CytoscapeNode:
+    return CytoscapeNode(
+        data=CytoscapeNodeData(
+            id=node_id,
+            label=node_id,
+            doc=None,
+            tool_id=None,
+            step_type="input",
+            repo_link=None,
+        ),
+        classes=[],
+    )
+
+
+def _e(source: str, target: str) -> CytoscapeEdge:
+    return CytoscapeEdge(
+        data=CytoscapeEdgeData(
+            id=f"{target}__in__from__{source}",
+            source=source,
+            target=target,
+            input="in",
+            output=None,
+        )
+    )
+
+
+def _positions(nodes: list[CytoscapeNode], edges: list[CytoscapeEdge]) -> dict[str, tuple[int, int]]:
+    elements = CytoscapeElements(nodes=nodes, edges=edges)
+    return {nid: (p.x, p.y) for nid, p in topological_positions(elements).items()}
+
+
+def test_stride_constants():
+    assert COL_STRIDE == 220
+    assert ROW_STRIDE == 100
+
+
+def test_linear_chain():
+    assert _positions(
+        [_n("A"), _n("B"), _n("C")],
+        [_e("A", "B"), _e("B", "C")],
+    ) == {"A": (0, 0), "B": (220, 0), "C": (440, 0)}
+
+
+def test_diamond():
+    assert _positions(
+        [_n("A"), _n("B"), _n("C"), _n("D")],
+        [_e("A", "B"), _e("A", "C"), _e("B", "D"), _e("C", "D")],
+    ) == {"A": (0, 0), "B": (220, 0), "C": (220, 100), "D": (440, 0)}
+
+
+def test_fan_out():
+    assert _positions(
+        [_n("A"), _n("B"), _n("C")],
+        [_e("A", "B"), _e("A", "C")],
+    ) == {"A": (0, 0), "B": (220, 0), "C": (220, 100)}
+
+
+def test_fan_in():
+    assert _positions(
+        [_n("A"), _n("B"), _n("C")],
+        [_e("A", "C"), _e("B", "C")],
+    ) == {"A": (0, 0), "B": (0, 100), "C": (220, 0)}
+
+
+def test_disconnected_components_stack_vertically():
+    assert _positions(
+        [_n("A"), _n("B"), _n("X"), _n("Y")],
+        [_e("A", "B"), _e("X", "Y")],
+    ) == {"A": (0, 0), "B": (220, 0), "X": (0, 100), "Y": (220, 100)}
+
+
+def test_longest_path_layering():
+    # A → B → D and A → D directly; D's column = max(B, A) + 1 = 2.
+    assert _positions(
+        [_n("A"), _n("B"), _n("D")],
+        [_e("A", "B"), _e("A", "D"), _e("B", "D")],
+    ) == {"A": (0, 0), "B": (220, 0), "D": (440, 0)}
+
+
+def test_ignores_unknown_source_nodes():
+    assert _positions(
+        [_n("A"), _n("B")],
+        [_e("A", "B"), _e("ghost", "B")],
+    ) == {"A": (0, 0), "B": (220, 0)}

--- a/tests/test_cytoscape_layout_integration.py
+++ b/tests/test_cytoscape_layout_integration.py
@@ -1,0 +1,72 @@
+"""Integration of ``layout`` through the cytoscape builder.
+
+Asserts:
+  - default emit equals layout="preset" (back-compat for the JSON shape).
+  - topological overwrites coordinates and sets the layout hint.
+  - hint-only layouts (dagre) drop ``position`` and set the layout hint.
+"""
+
+import pytest
+
+from gxformat2.cytoscape import cytoscape_elements
+
+WORKFLOW = {
+    "class": "GalaxyWorkflow",
+    "inputs": {"input_a": "data"},
+    "steps": [
+        {
+            "id": "tool_a",
+            "label": "tool_a",
+            "tool_id": "cat1",
+            "in": {"in": "input_a"},
+        },
+        {
+            "id": "tool_b",
+            "label": "tool_b",
+            "tool_id": "cat1",
+            "in": {"in": "tool_a/output"},
+        },
+    ],
+}
+
+
+def test_default_equals_preset():
+    a = cytoscape_elements(WORKFLOW)
+    b = cytoscape_elements(WORKFLOW, layout="preset")
+    assert a.to_list() == b.to_list()
+    assert a.layout is None
+
+
+def test_topological_overwrites_positions():
+    elements = cytoscape_elements(WORKFLOW, layout="topological")
+    assert elements.layout is not None
+    assert elements.layout.name == "topological"
+    by_id = {n.data.id: (n.position.x, n.position.y) for n in elements.nodes}
+    assert by_id["input_a"] == (0, 0)
+    assert by_id["tool_a"] == (220, 0)
+    assert by_id["tool_b"] == (440, 0)
+
+
+def test_dagre_drops_positions():
+    elements = cytoscape_elements(WORKFLOW, layout="dagre")
+    assert elements.layout is not None
+    assert elements.layout.name == "dagre"
+    for node in elements.nodes:
+        assert node.position is None
+    # to_list() drops the ``position`` key entirely for hint-only layouts.
+    for el in elements.to_list():
+        if el["group"] == "nodes":
+            assert "position" not in el
+
+
+def test_unknown_layout_rejected():
+    with pytest.raises(ValueError):
+        cytoscape_elements(WORKFLOW, layout="bogus")
+
+
+def test_to_dict_wraps_with_layout_hint():
+    elements = cytoscape_elements(WORKFLOW, layout="topological")
+    payload = elements.to_dict()
+    assert payload["layout"] == {"name": "topological"}
+    assert isinstance(payload["elements"], list)
+    assert len(payload["elements"]) == len(elements.nodes) + len(elements.edges)


### PR DESCRIPTION
## Summary

Adds `--layout <name>` to `gxwf-viz` (and the underlying `cytoscape_elements(workflow, *, layout=...)` builder), with a small cross-language layering algorithm so positionless workflows render usefully and runtime renderers (cytoscape.js, gxwf-ui) get a layout hint to honor.

Names match cytoscape.js's layout vocabulary so the hint is meaningful to anyone who knows the library.

| Layout | Coordinates | Hint emitted |
|---|---|---|
| `preset` (default) | `step.position` (or `(10*i, 10*i)` fallback) | none |
| `topological` | computed leveled layout (longest-path layering) | `layout: { name: "topological" }` |
| `dagre` / `breadthfirst` / `grid` / `cose` / `random` | omitted (renderer's job) | `layout: { name: "<n>" }` |

`preset` is byte-identical to today's behavior. `topological` is a small longest-path layering (~30 LOC) pinned to a normative cross-language spec living at [`galaxy-tool-util-ts/docs/architecture/cytoscape-layout.md`](https://github.com/jmchilton/galaxy-tool-util-ts) — the TS port emits byte-identical coordinates for the same workflow.

JSON output gains a `{ "elements": [...], "layout": { "name": "<n>" } }` wrapper when `--layout` is non-default. The default `preset` flow continues to write a bare list for back-compat.

The HTML template is synced verbatim from the TS port — adds `cytoscape-dagre` + `dagre` CDN scripts and a `\$layout` substitution token. If dagre fails to load (offline), the bootstrap falls back to `preset`.

## Cross-language parity

Verified end-to-end against `tests/examples/format2/real-multi-data-input.gxwf.yml`: the Python and TS CLIs emit identical positions and identical layout hints. The 8 hand-curated coordinate cases in `tests/test_cytoscape_layout.py` mirror the TS suite exactly — any drift in either implementation breaks both.

## Companion work

- TypeScript port: galaxy-tool-util-ts \`cytoscape-layout\` branch (the spec doc + `gxwf cytoscapejs --layout` ship there).

## Test plan

- [x] `make lint` clean
- [x] `python -m pytest tests/` — 655 passed, 8 skipped
- [x] `gxwf-viz fixture.gxwf.yml out.json` — flat list, positions present (back-compat)
- [x] `gxwf-viz fixture.gxwf.yml out.json --layout topological` — wrapped `{elements, layout}`, positions baked
- [x] `gxwf-viz fixture.gxwf.yml out.html --layout dagre` — HTML viewer renders with dagre at view time
- [x] Cross-language byte parity verified against TS port

🤖 Generated with [Claude Code](https://claude.com/claude-code)