### PR TITLE
Fix integer order_index step keys in native workflow loading

### DIFF
--- a/gxformat2/normalized/_native.py
+++ b/gxformat2/normalized/_native.py
@@ -216,7 +216,7 @@ def _normalize_native_for_validation(data: dict[str, Any]) -> dict[str, Any]:
         for key, step in data["steps"].items():
             if isinstance(step, dict):
                 step = _normalize_step_for_validation(step)
-            steps[key] = step
+            steps[str(key)] = step  # Galaxy may use integer order_index as keys
         data["steps"] = steps
     return data
 

--- a/tests/test_load_native.py
+++ b/tests/test_load_native.py
@@ -31,6 +31,19 @@ class TestLoadNativeStrict:
         result = load_native(wf, strict=True)
         assert result.tags == ["a", "b"]
 
+    def test_integer_step_keys_rejected(self):
+        wf = {
+            **MINIMAL_WORKFLOW,
+            "steps": {
+                0: {
+                    "id": 0,
+                    "type": "data_input",
+                },
+            },
+        }
+        with pytest.raises(ValidationError, match="Input should be a valid string"):
+            load_native(wf, strict=True)
+
 
 class TestLoadNativeLax:
     """Lax mode normalizes known quirks."""
@@ -126,6 +139,20 @@ class TestLoadNativeLax:
         result = load_native(wf, strict=False)
         pja = result.steps["0"].post_job_actions["RenameOut"]
         assert pja.action_arguments == {"newname": "renamed"}
+
+    def test_integer_step_keys_normalized_to_strings(self):
+        """Galaxy serializes steps with integer order_index keys; lax mode converts them to strings."""
+        wf = {
+            **MINIMAL_WORKFLOW,
+            "steps": {
+                0: {
+                    "id": 0,
+                    "type": "data_input",
+                },
+            },
+        }
+        result = load_native(wf, strict=False)
+        assert set(result.steps.keys()) == {"0"}
 
     def test_does_not_mutate_input(self):
         wf = {**MINIMAL_WORKFLOW, "tags": "a,b"}


### PR DESCRIPTION
Galaxy `WorkflowContentsManager._workflow_to_dict_export()` serializes workflow steps using the integer ``order_index`` as the dict key (e.g. ``{0: {...}, 1: {...}}``), but
``NativeGalaxyWorkflow.steps`` is typed as ``dict[str, NativeStep]``. Pydantic v2 does not coerce integer keys to strings, so ``NativeGalaxyWorkflow.model_validate()`` raised a ``ValidationError`` whenever ``load_native()`` / ``from_galaxy_native()`` was called on a workflow dict produced directly by Galaxy (e.g. during export or invocation download).

Fix: stringify every step key in ``_normalize_native_for_validation`` before the model is validated, so both lax and strict paths see string keys (strict still rejects them because the coercion happens after the strict-vs-lax branch).