### PR TITLE
Clarify input type aliases; move input_parameter_class out of generated file

### DIFF
--- a/gxformat2/normalized/_conversion.py
+++ b/gxformat2/normalized/_conversion.py
@@ -44,10 +44,10 @@ from ..schema.gxformat2 import (
     FrameComment,
     FreehandComment,
     GalaxyWorkflow,
-    input_parameter_class,
     MarkdownComment,
     Report,
 )
+from ..schema._input_parameter import input_parameter_class
 from ..schema.gxformat2 import StepPosition as Format2StepPosition
 from ..schema.gxformat2 import (
     TextComment,

--- a/gxformat2/normalized/_format2.py
+++ b/gxformat2/normalized/_format2.py
@@ -25,7 +25,6 @@ from gxformat2.schema.gxformat2 import (
     FrameComment,
     FreehandComment,
     GalaxyWorkflow,
-    input_parameter_class,
     MarkdownComment,
     Report,
     StepPosition,
@@ -38,6 +37,7 @@ from gxformat2.schema.gxformat2 import (
     WorkflowStepOutput,
     WorkflowStepType,
 )
+from gxformat2.schema._input_parameter import input_parameter_class
 from gxformat2.schema.gxformat2_strict import GalaxyWorkflow as StrictGalaxyWorkflow
 from gxformat2.yaml import ordered_load_path
 

--- a/gxformat2/schema/_input_parameter.py
+++ b/gxformat2/schema/_input_parameter.py
@@ -1,0 +1,45 @@
+"""Hand-written helper for resolving Format2 input ``type`` strings to the
+corresponding pydantic model class.
+
+The discriminator map mirrors ``pydantic:discriminator_map`` on
+``Process.inputs`` in ``schema/v19_09/Process.yml``. Keep the two in sync.
+
+Lives outside the generated modules in this package so ``build_schema.sh``
+regeneration does not clobber it.
+"""
+
+from .gxformat2 import (
+    BaseInputParameter,
+    WorkflowBooleanParameter,
+    WorkflowCollectionParameter,
+    WorkflowDataParameter,
+    WorkflowFloatParameter,
+    WorkflowIntegerParameter,
+    WorkflowTextParameter,
+)
+
+_INPUT_TYPE_TO_CLASS: dict[str, type[BaseInputParameter]] = {
+    "data": WorkflowDataParameter,
+    "File": WorkflowDataParameter,
+    "data_input": WorkflowDataParameter,
+    "collection": WorkflowCollectionParameter,
+    "data_collection": WorkflowCollectionParameter,
+    "data_collection_input": WorkflowCollectionParameter,
+    "integer": WorkflowIntegerParameter,
+    "int": WorkflowIntegerParameter,
+    "text": WorkflowTextParameter,
+    "string": WorkflowTextParameter,
+    "float": WorkflowFloatParameter,
+    "boolean": WorkflowBooleanParameter,
+    "color": WorkflowTextParameter,
+}
+
+
+def input_parameter_class(type_value: str | None) -> type[BaseInputParameter]:
+    """Return the specific input parameter class for a Format2 type string.
+
+    Falls back to WorkflowDataParameter for unknown or None types.
+    """
+    if type_value is None:
+        return WorkflowDataParameter
+    return _INPUT_TYPE_TO_CLASS.get(type_value, WorkflowDataParameter)

--- a/gxformat2/schema/_input_parameter.py
+++ b/gxformat2/schema/_input_parameter.py
@@ -8,6 +8,8 @@ Lives outside the generated modules in this package so ``build_schema.sh``
 regeneration does not clobber it.
 """
 
+from __future__ import annotations
+
 from .gxformat2 import (
     BaseInputParameter,
     WorkflowBooleanParameter,

--- a/gxformat2/schema/_input_parameter.py
+++ b/gxformat2/schema/_input_parameter.py
@@ -1,5 +1,4 @@
-"""Hand-written helper for resolving Format2 input ``type`` strings to the
-corresponding pydantic model class.
+"""Resolve Format2 input ``type`` strings to pydantic model classes.
 
 The discriminator map mirrors ``pydantic:discriminator_map`` on
 ``Process.inputs`` in ``schema/v19_09/Process.yml``. Keep the two in sync.

--- a/gxformat2/schema/gxformat2.py
+++ b/gxformat2/schema/gxformat2.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from enum import Enum
 from pathlib import Path
-from typing import Any, Annotated, Literal
+from typing import Any, Annotated, Literal, Union
 
 from pydantic import BaseModel, ConfigDict, Field, Discriminator, Tag
 
@@ -38,12 +38,15 @@ string: Unicode character sequence"""
 
 
 class GalaxyType(str, Enum):
-    """Extends primitive types with the native Galaxy concepts such datasets and collections.
-integer: an alias for int type - matches syntax used by Galaxy tools
-text: an alias for string type - matches syntax used by Galaxy tools
-File: an alias for data - there are subtle differences between a plain file, the CWL concept of 'File', and the Galaxy concept of a dataset - this may have subtly difference semantics in the future
-data: a Galaxy dataset
-collection: a Galaxy dataset collection"""
+    """Extends primitive types with the native Galaxy concepts such as datasets and collections.
+Normalized gxformat2 workflow input declaration spellings are ``data``, ``collection``, ``string``, ``int``, ``float``, and ``boolean``. Other spellings are accepted as compatibility aliases on import but normalized gxformat2 output emits the normalized spellings.
+data: one Galaxy dataset input. Native Galaxy ``data_input`` converts to this spelling.
+File: accepted alias for ``data``, but normalized gxformat2 output emits ``data``. Note: workflow **test job** YAML uses ``type: File`` to mean 'stage this file as test input data', which is a separate concept from workflow input declaration.
+collection: one Galaxy dataset collection input. Native Galaxy ``data_collection_input`` converts to this spelling.
+string: normalized gxformat2 spelling for native Galaxy text workflow parameters.
+text: accepted alias for ``string`` because native Galaxy parameter state and Galaxy tool XML terminology use ``text``.
+int: normalized gxformat2 spelling for native Galaxy integer workflow parameters.
+integer: accepted alias for ``int`` because native Galaxy parameter state and Galaxy tool XML terminology use ``integer``."""
 
     null = "null"
     boolean = "boolean"
@@ -75,21 +78,7 @@ pick_value: Select the first non-null value from multiple inputs. Used to merge 
 
 
 def _discriminate_inputs(v: Any) -> str:
-    disc_map: dict[str, str] = {
-        "data": "WorkflowDataParameter",
-        "File": "WorkflowDataParameter",
-        "data_input": "WorkflowDataParameter",
-        "collection": "WorkflowCollectionParameter",
-        "data_collection": "WorkflowCollectionParameter",
-        "data_collection_input": "WorkflowCollectionParameter",
-        "integer": "WorkflowIntegerParameter",
-        "int": "WorkflowIntegerParameter",
-        "text": "WorkflowTextParameter",
-        "string": "WorkflowTextParameter",
-        "float": "WorkflowFloatParameter",
-        "boolean": "WorkflowBooleanParameter",
-        "color": "WorkflowTextParameter",
-    }
+    disc_map: dict[str, str] = {"data": "WorkflowDataParameter", "File": "WorkflowDataParameter", "data_input": "WorkflowDataParameter", "collection": "WorkflowCollectionParameter", "data_collection": "WorkflowCollectionParameter", "data_collection_input": "WorkflowCollectionParameter", "integer": "WorkflowIntegerParameter", "int": "WorkflowIntegerParameter", "text": "WorkflowTextParameter", "string": "WorkflowTextParameter", "float": "WorkflowFloatParameter", "boolean": "WorkflowBooleanParameter", "color": "WorkflowTextParameter"}
     if isinstance(v, dict):
         disc_val: str = str(v.get("type", ""))
     else:
@@ -169,20 +158,7 @@ directly executed."""
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 
     # Discriminated union on 'type'
-    inputs: (
-        list[Annotated[
-            Annotated[WorkflowDataParameter, Tag("WorkflowDataParameter")]
-            | Annotated[WorkflowCollectionParameter, Tag("WorkflowCollectionParameter")]
-            | Annotated[WorkflowIntegerParameter, Tag("WorkflowIntegerParameter")]
-            | Annotated[WorkflowFloatParameter, Tag("WorkflowFloatParameter")]
-            | Annotated[WorkflowTextParameter, Tag("WorkflowTextParameter")]
-            | Annotated[WorkflowBooleanParameter, Tag("WorkflowBooleanParameter")],
-            Discriminator(_discriminate_inputs),
-        ]]
-        | dict[str, WorkflowDataParameter | WorkflowCollectionParameter | WorkflowIntegerParameter
-               | WorkflowFloatParameter | WorkflowTextParameter | WorkflowBooleanParameter | str]
-        | dict[str, Any]
-    )
+    inputs: list[Annotated[Annotated[WorkflowDataParameter, Tag("WorkflowDataParameter")] | Annotated[WorkflowCollectionParameter, Tag("WorkflowCollectionParameter")] | Annotated[WorkflowIntegerParameter, Tag("WorkflowIntegerParameter")] | Annotated[WorkflowFloatParameter, Tag("WorkflowFloatParameter")] | Annotated[WorkflowTextParameter, Tag("WorkflowTextParameter")] | Annotated[WorkflowBooleanParameter, Tag("WorkflowBooleanParameter")], Discriminator(_discriminate_inputs)]] | dict[str, WorkflowDataParameter | WorkflowCollectionParameter | WorkflowIntegerParameter | WorkflowFloatParameter | WorkflowTextParameter | WorkflowBooleanParameter | str] | dict[str, Any]
     outputs: list[WorkflowOutputParameter] | dict[str, WorkflowOutputParameter | str] | dict[str, Any] = Field(description="Defines the parameters representing the output of the process.  May be used to generate and/or validate the output object.")
 
 class HasUUID(BaseModel):
@@ -229,18 +205,32 @@ class BaseInputParameter(InputParameter, HasStepPosition):
     id: None | str = Field(default=None, description="The unique identifier for this object.")
     label: None | str = Field(default=None, description="A short, human-readable label of this object.")
     doc: None | str | list[str] = Field(default=None, description="A documentation string for this object, or an array of strings which should be concatenated.")
-    optional: bool | None = Field(default=None, description="If set to true, `WorkflowInputParameter` is not required to submit the workflow.")
+    optional: bool | None = Field(default=None, description="Controls whether Galaxy allows invocation of the workflow without a user-supplied value for this input. If ``true``, the input may be omitted at invocation time. ``optional`` and ``default`` are in...")
 
 class BaseDataParameter(BaseInputParameter):
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 
+    id: None | str = Field(default=None, description="The unique identifier for this object.")
+    label: None | str = Field(default=None, description="A short, human-readable label of this object.")
+    doc: None | str | list[str] = Field(default=None, description="A documentation string for this object, or an array of strings which should be concatenated.")
+    default: None | Any = Field(default=None, description="The default value to use for this parameter if the parameter is missing from the input object, or if the value of the parameter in the input object is `null`.  Default values are applied before eva...")
+    position: None | StepPosition = Field(default=None)
     format: None | list[str] = Field(default=None, description="Specify datatype extensions for valid input datasets.")
 
 class WorkflowDataParameter(BaseDataParameter):
-    """A data input parameter for a Galaxy workflow - represents a dataset."""
+    """A data input parameter for a Galaxy workflow. Represents one Galaxy dataset.
+Normalized gxformat2 output uses ``type: data``. ``type: File`` is accepted as
+an alias, but should not be confused with workflow test job syntax where
+``type: File`` means stage a file as test input data."""
 
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 
+    id: None | str = Field(default=None, description="The unique identifier for this object.")
+    label: None | str = Field(default=None, description="A short, human-readable label of this object.")
+    doc: None | str | list[str] = Field(default=None, description="A documentation string for this object, or an array of strings which should be concatenated.")
+    default: None | Any = Field(default=None, description="The default value to use for this parameter if the parameter is missing from the input object, or if the value of the parameter in the input object is `null`.  Default values are applied before eva...")
+    position: None | StepPosition = Field(default=None)
+    optional: bool | None = Field(default=None, description="Controls whether Galaxy allows invocation of the workflow without a user-supplied value for this input. If ``true``, the input may be omitted at invocation time. ``optional`` and ``default`` are in...")
     type_: Literal["data", "File"] | None = Field(default=None, alias="type", description="Specify valid types of data that may be assigned to this parameter.")
 
 class WorkflowCollectionParameter(BaseDataParameter):
@@ -248,6 +238,12 @@ class WorkflowCollectionParameter(BaseDataParameter):
 
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 
+    id: None | str = Field(default=None, description="The unique identifier for this object.")
+    label: None | str = Field(default=None, description="A short, human-readable label of this object.")
+    doc: None | str | list[str] = Field(default=None, description="A documentation string for this object, or an array of strings which should be concatenated.")
+    default: None | Any = Field(default=None, description="The default value to use for this parameter if the parameter is missing from the input object, or if the value of the parameter in the input object is `null`.  Default values are applied before eva...")
+    position: None | StepPosition = Field(default=None)
+    optional: bool | None = Field(default=None, description="Controls whether Galaxy allows invocation of the workflow without a user-supplied value for this input. If ``true``, the input may be omitted at invocation time. ``optional`` and ``default`` are in...")
     type_: Literal["collection"] = Field(default="collection", alias="type", description="Must be ``collection``.")
     collection_type: None | str = Field(default=None, description="Collection type (defaults to `list` if `type` is `collection`). Nested collection types are separated with colons, e.g. `list:list:paired`.")
 
@@ -258,10 +254,17 @@ class MinMax(BaseModel):
     max: int | float | None = Field(default=None, description="Maximum allowed value (inclusive).")
 
 class WorkflowIntegerParameter(BaseInputParameter, MinMax):
-    """An integer input parameter for a Galaxy workflow."""
+    """A scalar integer workflow parameter. Normalized gxformat2 output uses
+``type: int``. ``type: integer`` is accepted for compatibility with native
+Galaxy parameter state and Galaxy tool XML terminology."""
 
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 
+    id: None | str = Field(default=None, description="The unique identifier for this object.")
+    label: None | str = Field(default=None, description="A short, human-readable label of this object.")
+    doc: None | str | list[str] = Field(default=None, description="A documentation string for this object, or an array of strings which should be concatenated.")
+    default: None | Any = Field(default=None, description="The default value to use for this parameter if the parameter is missing from the input object, or if the value of the parameter in the input object is `null`.  Default values are applied before eva...")
+    position: None | StepPosition = Field(default=None)
     type_: Literal["integer", "int"] = Field(default="integer", alias="type", description="Must be ``integer`` or ``int``.")
 
 class WorkflowFloatParameter(BaseInputParameter, MinMax):
@@ -269,13 +272,25 @@ class WorkflowFloatParameter(BaseInputParameter, MinMax):
 
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 
+    id: None | str = Field(default=None, description="The unique identifier for this object.")
+    label: None | str = Field(default=None, description="A short, human-readable label of this object.")
+    doc: None | str | list[str] = Field(default=None, description="A documentation string for this object, or an array of strings which should be concatenated.")
+    default: None | Any = Field(default=None, description="The default value to use for this parameter if the parameter is missing from the input object, or if the value of the parameter in the input object is `null`.  Default values are applied before eva...")
+    position: None | StepPosition = Field(default=None)
     type_: Literal["float"] = Field(default="float", alias="type", description="Must be ``float``.")
 
 class WorkflowTextParameter(BaseInputParameter):
-    """A text input parameter for a Galaxy workflow."""
+    """A scalar text workflow parameter. Normalized gxformat2 output uses
+``type: string``. ``type: text`` is accepted for compatibility with native
+Galaxy parameter state and Galaxy tool XML terminology."""
 
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 
+    id: None | str = Field(default=None, description="The unique identifier for this object.")
+    label: None | str = Field(default=None, description="A short, human-readable label of this object.")
+    doc: None | str | list[str] = Field(default=None, description="A documentation string for this object, or an array of strings which should be concatenated.")
+    default: None | Any = Field(default=None, description="The default value to use for this parameter if the parameter is missing from the input object, or if the value of the parameter in the input object is `null`.  Default values are applied before eva...")
+    position: None | StepPosition = Field(default=None)
     type_: Literal["text", "string"] = Field(default="text", alias="type", description="Must be ``text`` or ``string``.")
 
 class WorkflowBooleanParameter(BaseInputParameter):
@@ -283,6 +298,11 @@ class WorkflowBooleanParameter(BaseInputParameter):
 
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 
+    id: None | str = Field(default=None, description="The unique identifier for this object.")
+    label: None | str = Field(default=None, description="A short, human-readable label of this object.")
+    doc: None | str | list[str] = Field(default=None, description="A documentation string for this object, or an array of strings which should be concatenated.")
+    default: None | Any = Field(default=None, description="The default value to use for this parameter if the parameter is missing from the input object, or if the value of the parameter in the input object is `null`.  Default values are applied before eva...")
+    position: None | StepPosition = Field(default=None)
     type_: Literal["boolean"] = Field(default="boolean", alias="type", description="Must be ``boolean``.")
 
 class WorkflowInputParameter(BaseDataParameter, MinMax):
@@ -292,6 +312,12 @@ of the specific parameter types instead."""
 
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 
+    id: None | str = Field(default=None, description="The unique identifier for this object.")
+    label: None | str = Field(default=None, description="A short, human-readable label of this object.")
+    doc: None | str | list[str] = Field(default=None, description="A documentation string for this object, or an array of strings which should be concatenated.")
+    default: None | Any = Field(default=None, description="The default value to use for this parameter if the parameter is missing from the input object, or if the value of the parameter in the input object is `null`.  Default values are applied before eva...")
+    position: None | StepPosition = Field(default=None)
+    optional: bool | None = Field(default=None, description="Controls whether Galaxy allows invocation of the workflow without a user-supplied value for this input. If ``true``, the input may be omitted at invocation time. ``optional`` and ``default`` are in...")
     type_: GalaxyType | None | list[GalaxyType] = Field(default=None, alias="type", description="Specify valid types of data that may be assigned to this parameter.")
     collection_type: None | str = Field(default=None, description="Collection type (defaults to `list` if `type` is `collection`). Nested collection types are separated with colons, e.g. `list:list:paired`.")
 
@@ -547,30 +573,3 @@ def load_document(path: str | Path) -> GalaxyWorkflow | list[GalaxyWorkflow]:
 def _load_single(data: dict[str, Any]) -> GalaxyWorkflow:
     """Load a single document dict."""
     return GalaxyWorkflow.model_validate(data)
-
-
-_INPUT_TYPE_TO_CLASS: dict[str, type[BaseInputParameter]] = {
-    "data": WorkflowDataParameter,
-    "File": WorkflowDataParameter,
-    "data_input": WorkflowDataParameter,
-    "collection": WorkflowCollectionParameter,
-    "data_collection": WorkflowCollectionParameter,
-    "data_collection_input": WorkflowCollectionParameter,
-    "integer": WorkflowIntegerParameter,
-    "int": WorkflowIntegerParameter,
-    "text": WorkflowTextParameter,
-    "string": WorkflowTextParameter,
-    "float": WorkflowFloatParameter,
-    "boolean": WorkflowBooleanParameter,
-    "color": WorkflowTextParameter,
-}
-
-
-def input_parameter_class(type_value: str | None) -> type[BaseInputParameter]:
-    """Return the specific input parameter class for a Format2 type string.
-
-    Falls back to WorkflowDataParameter for unknown or None types.
-    """
-    if type_value is None:
-        return WorkflowDataParameter
-    return _INPUT_TYPE_TO_CLASS.get(type_value, WorkflowDataParameter)

--- a/gxformat2/schema/gxformat2_strict.py
+++ b/gxformat2/schema/gxformat2_strict.py
@@ -38,12 +38,15 @@ string: Unicode character sequence"""
 
 
 class GalaxyType(str, Enum):
-    """Extends primitive types with the native Galaxy concepts such datasets and collections.
-integer: an alias for int type - matches syntax used by Galaxy tools
-text: an alias for string type - matches syntax used by Galaxy tools
-File: an alias for data - there are subtle differences between a plain file, the CWL concept of 'File', and the Galaxy concept of a dataset - this may have subtly difference semantics in the future
-data: a Galaxy dataset
-collection: a Galaxy dataset collection"""
+    """Extends primitive types with the native Galaxy concepts such as datasets and collections.
+Normalized gxformat2 workflow input declaration spellings are ``data``, ``collection``, ``string``, ``int``, ``float``, and ``boolean``. Other spellings are accepted as compatibility aliases on import but normalized gxformat2 output emits the normalized spellings.
+data: one Galaxy dataset input. Native Galaxy ``data_input`` converts to this spelling.
+File: accepted alias for ``data``, but normalized gxformat2 output emits ``data``. Note: workflow **test job** YAML uses ``type: File`` to mean 'stage this file as test input data', which is a separate concept from workflow input declaration.
+collection: one Galaxy dataset collection input. Native Galaxy ``data_collection_input`` converts to this spelling.
+string: normalized gxformat2 spelling for native Galaxy text workflow parameters.
+text: accepted alias for ``string`` because native Galaxy parameter state and Galaxy tool XML terminology use ``text``.
+int: normalized gxformat2 spelling for native Galaxy integer workflow parameters.
+integer: accepted alias for ``int`` because native Galaxy parameter state and Galaxy tool XML terminology use ``integer``."""
 
     null = "null"
     boolean = "boolean"
@@ -202,7 +205,7 @@ class BaseInputParameter(InputParameter, HasStepPosition):
     id: None | str = Field(default=None, description="The unique identifier for this object.")
     label: None | str = Field(default=None, description="A short, human-readable label of this object.")
     doc: None | str | list[str] = Field(default=None, description="A documentation string for this object, or an array of strings which should be concatenated.")
-    optional: bool | None = Field(default=None, description="If set to true, `WorkflowInputParameter` is not required to submit the workflow.")
+    optional: bool | None = Field(default=None, description="Controls whether Galaxy allows invocation of the workflow without a user-supplied value for this input. If ``true``, the input may be omitted at invocation time. ``optional`` and ``default`` are in...")
 
 class BaseDataParameter(BaseInputParameter):
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
@@ -215,7 +218,10 @@ class BaseDataParameter(BaseInputParameter):
     format: None | list[str] = Field(default=None, description="Specify datatype extensions for valid input datasets.")
 
 class WorkflowDataParameter(BaseDataParameter):
-    """A data input parameter for a Galaxy workflow - represents a dataset."""
+    """A data input parameter for a Galaxy workflow. Represents one Galaxy dataset.
+Normalized gxformat2 output uses ``type: data``. ``type: File`` is accepted as
+an alias, but should not be confused with workflow test job syntax where
+``type: File`` means stage a file as test input data."""
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
@@ -224,7 +230,7 @@ class WorkflowDataParameter(BaseDataParameter):
     doc: None | str | list[str] = Field(default=None, description="A documentation string for this object, or an array of strings which should be concatenated.")
     default: None | Any = Field(default=None, description="The default value to use for this parameter if the parameter is missing from the input object, or if the value of the parameter in the input object is `null`.  Default values are applied before eva...")
     position: None | StepPosition = Field(default=None)
-    optional: bool | None = Field(default=None, description="If set to true, `WorkflowInputParameter` is not required to submit the workflow.")
+    optional: bool | None = Field(default=None, description="Controls whether Galaxy allows invocation of the workflow without a user-supplied value for this input. If ``true``, the input may be omitted at invocation time. ``optional`` and ``default`` are in...")
     type_: Literal["data", "File"] | None = Field(default=None, alias="type", description="Specify valid types of data that may be assigned to this parameter.")
 
 class WorkflowCollectionParameter(BaseDataParameter):
@@ -237,7 +243,7 @@ class WorkflowCollectionParameter(BaseDataParameter):
     doc: None | str | list[str] = Field(default=None, description="A documentation string for this object, or an array of strings which should be concatenated.")
     default: None | Any = Field(default=None, description="The default value to use for this parameter if the parameter is missing from the input object, or if the value of the parameter in the input object is `null`.  Default values are applied before eva...")
     position: None | StepPosition = Field(default=None)
-    optional: bool | None = Field(default=None, description="If set to true, `WorkflowInputParameter` is not required to submit the workflow.")
+    optional: bool | None = Field(default=None, description="Controls whether Galaxy allows invocation of the workflow without a user-supplied value for this input. If ``true``, the input may be omitted at invocation time. ``optional`` and ``default`` are in...")
     type_: Literal["collection"] = Field(default="collection", alias="type", description="Must be ``collection``.")
     collection_type: None | str = Field(default=None, description="Collection type (defaults to `list` if `type` is `collection`). Nested collection types are separated with colons, e.g. `list:list:paired`.")
 
@@ -248,7 +254,9 @@ class MinMax(BaseModel):
     max: int | float | None = Field(default=None, description="Maximum allowed value (inclusive).")
 
 class WorkflowIntegerParameter(BaseInputParameter, MinMax):
-    """An integer input parameter for a Galaxy workflow."""
+    """A scalar integer workflow parameter. Normalized gxformat2 output uses
+``type: int``. ``type: integer`` is accepted for compatibility with native
+Galaxy parameter state and Galaxy tool XML terminology."""
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
@@ -272,7 +280,9 @@ class WorkflowFloatParameter(BaseInputParameter, MinMax):
     type_: Literal["float"] = Field(default="float", alias="type", description="Must be ``float``.")
 
 class WorkflowTextParameter(BaseInputParameter):
-    """A text input parameter for a Galaxy workflow."""
+    """A scalar text workflow parameter. Normalized gxformat2 output uses
+``type: string``. ``type: text`` is accepted for compatibility with native
+Galaxy parameter state and Galaxy tool XML terminology."""
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
@@ -307,7 +317,7 @@ of the specific parameter types instead."""
     doc: None | str | list[str] = Field(default=None, description="A documentation string for this object, or an array of strings which should be concatenated.")
     default: None | Any = Field(default=None, description="The default value to use for this parameter if the parameter is missing from the input object, or if the value of the parameter in the input object is `null`.  Default values are applied before eva...")
     position: None | StepPosition = Field(default=None)
-    optional: bool | None = Field(default=None, description="If set to true, `WorkflowInputParameter` is not required to submit the workflow.")
+    optional: bool | None = Field(default=None, description="Controls whether Galaxy allows invocation of the workflow without a user-supplied value for this input. If ``true``, the input may be omitted at invocation time. ``optional`` and ``default`` are in...")
     type_: GalaxyType | None | list[GalaxyType] = Field(default=None, alias="type", description="Specify valid types of data that may be assigned to this parameter.")
     collection_type: None | str = Field(default=None, description="Collection type (defaults to `list` if `type` is `collection`). Nested collection types are separated with colons, e.g. `list:list:paired`.")
 

--- a/gxformat2/schema/v19_09.py
+++ b/gxformat2/schema/v19_09.py
@@ -3569,7 +3569,10 @@ class BaseDataParameter(BaseInputParameter):
 
 class WorkflowDataParameter(BaseDataParameter):
     """
-    A data input parameter for a Galaxy workflow - represents a dataset.
+    A data input parameter for a Galaxy workflow. Represents one Galaxy dataset.
+    Normalized gxformat2 output uses ``type: data``. ``type: File`` is accepted as
+    an alias, but should not be confused with workflow test job syntax where
+    ``type: File`` means stage a file as test input data.
 
     """
 
@@ -4957,7 +4960,9 @@ class MinMax(Saveable):
 
 class WorkflowIntegerParameter(BaseInputParameter, MinMax):
     """
-    An integer input parameter for a Galaxy workflow.
+    A scalar integer workflow parameter. Normalized gxformat2 output uses
+    ``type: int``. ``type: integer`` is accepted for compatibility with native
+    Galaxy parameter state and Galaxy tool XML terminology.
 
     """
 
@@ -6191,7 +6196,9 @@ class WorkflowFloatParameter(BaseInputParameter, MinMax):
 
 class WorkflowTextParameter(BaseInputParameter):
     """
-    A text input parameter for a Galaxy workflow.
+    A scalar text workflow parameter. Normalized gxformat2 output uses
+    ``type: string``. ``type: text`` is accepted for compatibility with native
+    Galaxy parameter state and Galaxy tool XML terminology.
 
     """
 
@@ -15376,12 +15383,15 @@ GalaxyTypeLoader = _EnumLoader(
     "GalaxyType",
 )
 """
-Extends primitive types with the native Galaxy concepts such datasets and collections.
-integer: an alias for int type - matches syntax used by Galaxy tools
-text: an alias for string type - matches syntax used by Galaxy tools
-File: an alias for data - there are subtle differences between a plain file, the CWL concept of 'File', and the Galaxy concept of a dataset - this may have subtly difference semantics in the future
-data: a Galaxy dataset
-collection: a Galaxy dataset collection
+Extends primitive types with the native Galaxy concepts such as datasets and collections.
+Normalized gxformat2 workflow input declaration spellings are ``data``, ``collection``, ``string``, ``int``, ``float``, and ``boolean``. Other spellings are accepted as compatibility aliases on import but normalized gxformat2 output emits the normalized spellings.
+data: one Galaxy dataset input. Native Galaxy ``data_input`` converts to this spelling.
+File: accepted alias for ``data``, but normalized gxformat2 output emits ``data``. Note: workflow **test job** YAML uses ``type: File`` to mean 'stage this file as test input data', which is a separate concept from workflow input declaration.
+collection: one Galaxy dataset collection input. Native Galaxy ``data_collection_input`` converts to this spelling.
+string: normalized gxformat2 spelling for native Galaxy text workflow parameters.
+text: accepted alias for ``string`` because native Galaxy parameter state and Galaxy tool XML terminology use ``text``.
+int: normalized gxformat2 spelling for native Galaxy integer workflow parameters.
+integer: accepted alias for ``int`` because native Galaxy parameter state and Galaxy tool XML terminology use ``integer``.
 """
 WorkflowStepTypeLoader = _EnumLoader(
     (

--- a/schema/v19_09/workflow.yml
+++ b/schema/v19_09/workflow.yml
@@ -37,12 +37,15 @@ $graph:
     - data
     - collection
   doc:
-    - "Extends primitive types with the native Galaxy concepts such datasets and collections."
-    - "integer: an alias for int type - matches syntax used by Galaxy tools"
-    - "text: an alias for string type - matches syntax used by Galaxy tools"
-    - "File: an alias for data - there are subtle differences between a plain file, the CWL concept of 'File', and the Galaxy concept of a dataset - this may have subtly difference semantics in the future"
-    - "data: a Galaxy dataset"
-    - "collection: a Galaxy dataset collection"
+    - "Extends primitive types with the native Galaxy concepts such as datasets and collections."
+    - "Normalized gxformat2 workflow input declaration spellings are ``data``, ``collection``, ``string``, ``int``, ``float``, and ``boolean``. Other spellings are accepted as compatibility aliases on import but normalized gxformat2 output emits the normalized spellings."
+    - "data: one Galaxy dataset input. Native Galaxy ``data_input`` converts to this spelling."
+    - "File: accepted alias for ``data``, but normalized gxformat2 output emits ``data``. Note: workflow **test job** YAML uses ``type: File`` to mean 'stage this file as test input data', which is a separate concept from workflow input declaration."
+    - "collection: one Galaxy dataset collection input. Native Galaxy ``data_collection_input`` converts to this spelling."
+    - "string: normalized gxformat2 spelling for native Galaxy text workflow parameters."
+    - "text: accepted alias for ``string`` because native Galaxy parameter state and Galaxy tool XML terminology use ``text``."
+    - "int: normalized gxformat2 spelling for native Galaxy integer workflow parameters."
+    - "integer: accepted alias for ``int`` because native Galaxy parameter state and Galaxy tool XML terminology use ``integer``."
 
 
 - name: WorkflowStepType
@@ -73,7 +76,13 @@ $graph:
       - "null"
       default: false
       doc: |
-        If set to true, `WorkflowInputParameter` is not required to submit the workflow.
+        Controls whether Galaxy allows invocation of the workflow without a
+        user-supplied value for this input. If ``true``, the input may be omitted
+        at invocation time. ``optional`` and ``default`` are independent: a
+        required input (``optional: false``) may still declare a ``default``,
+        and an optional input may have no ``default``. ``default`` supplies a
+        value when the invocation input is missing or ``null``; ``optional``
+        controls whether the missing case is even permitted.
 
 - name: BaseDataParameter
   type: record
@@ -93,7 +102,10 @@ $graph:
     - BaseDataParameter
   docParent: "#GalaxyWorkflow"
   doc: |
-    A data input parameter for a Galaxy workflow - represents a dataset.
+    A data input parameter for a Galaxy workflow. Represents one Galaxy dataset.
+    Normalized gxformat2 output uses ``type: data``. ``type: File`` is accepted as
+    an alias, but should not be confused with workflow test job syntax where
+    ``type: File`` means stage a file as test input data.
   fields:
     - name: type
       type:
@@ -169,7 +181,9 @@ $graph:
     - MinMax
   docParent: "#GalaxyWorkflow"
   doc: |
-    An integer input parameter for a Galaxy workflow.
+    A scalar integer workflow parameter. Normalized gxformat2 output uses
+    ``type: int``. ``type: integer`` is accepted for compatibility with native
+    Galaxy parameter state and Galaxy tool XML terminology.
   fields:
     - name: type
       type: string
@@ -208,7 +222,9 @@ $graph:
     - BaseInputParameter
   docParent: "#GalaxyWorkflow"
   doc: |
-    A text input parameter for a Galaxy workflow.
+    A scalar text workflow parameter. Normalized gxformat2 output uses
+    ``type: string``. ``type: text`` is accepted for compatibility with native
+    Galaxy parameter state and Galaxy tool XML terminology.
   fields:
     - name: type
       type: string


### PR DESCRIPTION
## Summary

- SALAD doc updates per #200: distinguish normalized gxformat2 input declaration spellings (`data`, `collection`, `string`, `int`, `float`, `boolean`) from compatibility aliases (`File`, `data_input`, `data_collection`, `data_collection_input`, `text`, `integer`).
- Clarify the `type: File` ambiguity: workflow declaration alias for `data` vs. workflow test job `type: File` (stage a file as test input).
- Document `optional` / `default` independence on `BaseInputParameter`.
- Move `input_parameter_class` and `_INPUT_TYPE_TO_CLASS` from the generated `gxformat2/schema/gxformat2.py` (where they were hand-edited in 1a2d9ed and got clobbered on regen) into a new hand-written `gxformat2/schema/_input_parameter.py`. Consumers in `normalized/_format2.py` and `normalized/_conversion.py` updated.

## Why move the helper

No published version of `schema-salad-plus-pydantic` (0.1.3 → 0.1.10-dev) emits class-lookup helpers — only the private `_discriminate_X` discriminator function. The lookup is a gxformat2 application concern (manual single-class instantiation outside the discriminated parent), not generic codegen, so it lives in gxformat2 proper.

## Acceptance criteria from #200

- [x] SALAD docs distinguish normalized gxformat2 spellings from compatibility aliases.
- [x] Generated docs (Python docstrings in `gxformat2/schema/v19_09.py`) expose the distinction.
- [x] `File` documented as accepted alias, not normalized declaration spelling.
- [x] Workflow test job `type: File` explicitly distinguished from declaration `type: data`.
- [x] `optional` / `default` independence documented.

Open questions from #200 (not addressed here):
- Keep `long`/`double` in JSON Schema?
- Add `color`/`directory_uri` as gxformat2 input types?
- Compat aliases: silent vs. lint-warn?

## Test plan

- [x] `uv run --group test pytest tests/ -x -q` — 657 passed, 8 skipped
- [x] `uv run --group lint ruff check` — clean
- [x] `uv run --group mypy mypy gxformat2` — clean
- [x] `SKIP_JAVA=1 SKIP_TYPESCRIPT=1 bash build_schema.sh` — regenerates cleanly without clobbering the helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)