### PR TITLE
Restore Format2 legacy input aliases via legacy_compat flag (closes #205)

### DIFF
--- a/gxformat2/examples/catalog.yml
+++ b/gxformat2/examples/catalog.yml
@@ -617,3 +617,40 @@
   description: List-form steps without labels — triggers "no label" warning.
   tests:
     - tests/test_interop_tests.py
+
+# --- legacy compat fixtures (issue #205) ---
+
+- file: format2/synthetic-legacy-outputs-alias.gxwf.yml
+  origin: synthetic
+  format: format2
+  description: Step-level "outputs:" alias for "out:" (legacy compat A).
+  tests:
+    - tests/test_interop_tests.py
+
+- file: format2/synthetic-legacy-step-form-input.gxwf.yml
+  origin: synthetic
+  format: format2
+  description: 'Step entries with "type: input/input_collection" lifted to top-level inputs (legacy compat B).'
+  tests:
+    - tests/test_interop_tests.py
+
+- file: format2/synthetic-legacy-int-link.gxwf.yml
+  origin: synthetic
+  format: format2
+  description: "$link with integer value coerced to string (legacy compat C)."
+  tests:
+    - tests/test_interop_tests.py
+
+- file: format2/synthetic-legacy-float-tool-version.gxwf.yml
+  origin: synthetic
+  format: format2
+  description: Unquoted float tool_version coerced to string (legacy compat D).
+  tests:
+    - tests/test_interop_tests.py
+
+- file: format2/synthetic-legacy-list-source.gxwf.yml
+  origin: synthetic
+  format: format2
+  description: 'Bare list value in dict-form "in:" expanded to {source: [...]} (legacy compat F).'
+  tests:
+    - tests/test_interop_tests.py

--- a/gxformat2/examples/expectations/legacy_compat.yml
+++ b/gxformat2/examples/expectations/legacy_compat.yml
@@ -1,0 +1,65 @@
+test_legacy_outputs_alias:
+  fixture: synthetic-legacy-outputs-alias.gxwf.yml
+  operation: normalized_format2
+  assertions:
+    - path: [steps, $length]
+      value: 1
+    - path: [steps, 0, out, $length]
+      value: 1
+    - path: [steps, 0, out, 0, id]
+      value: out_file1
+    - path: [steps, 0, out, 0, rename]
+      value: renamed.txt
+
+test_legacy_outputs_alias_to_native_pja:
+  fixture: synthetic-legacy-outputs-alias.gxwf.yml
+  operation: to_native
+  assertions:
+    - path: [steps, "1", post_job_actions, RenameDatasetActionout_file1, action_type]
+      value: RenameDatasetAction
+
+test_legacy_step_form_input_lifted:
+  fixture: synthetic-legacy-step-form-input.gxwf.yml
+  operation: normalized_format2
+  assertions:
+    - path: [inputs, $length]
+      value: 2
+    - path: [inputs, {id: myinput}, type_]
+      value: data
+    - path: [inputs, {id: mycoll}, type_]
+      value: collection
+    - path: [steps, $length]
+      value: 1
+    - path: [steps, 0, tool_id]
+      value: cat1
+
+test_legacy_int_link_coerced:
+  fixture: synthetic-legacy-int-link.gxwf.yml
+  operation: normalized_format2
+  assertions:
+    - path: [steps, 0, in_, $length]
+      value: 1
+    - path: [steps, 0, in_, 0, id]
+      value: input1
+    - path: [steps, 0, in_, 0, source]
+      value: "0"
+
+test_legacy_float_tool_version_coerced:
+  fixture: synthetic-legacy-float-tool-version.gxwf.yml
+  operation: normalized_format2
+  assertions:
+    - path: [steps, 0, tool_version]
+      value: "0.1"
+
+test_legacy_list_source_in:
+  fixture: synthetic-legacy-list-source.gxwf.yml
+  operation: normalized_format2
+  assertions:
+    - path: [steps, 0, in_, $length]
+      value: 1
+    - path: [steps, 0, in_, 0, id]
+      value: input1
+    - path: [steps, 0, in_, 0, source]
+      value:
+        - input1
+        - input2

--- a/gxformat2/examples/format2/synthetic-legacy-float-tool-version.gxwf.yml
+++ b/gxformat2/examples/format2/synthetic-legacy-float-tool-version.gxwf.yml
@@ -1,0 +1,13 @@
+class: GalaxyWorkflow
+doc: |
+  Legacy compat D: unquoted ``tool_version: 0.1`` parses as a YAML float.
+  Pydantic v2 ``str | None`` does not coerce; legacy_compat coerces in
+  pre-pass.
+inputs:
+  input1: data
+steps:
+  cat:
+    tool_id: cat1
+    tool_version: 0.1
+    in:
+      input1: input1

--- a/gxformat2/examples/format2/synthetic-legacy-int-link.gxwf.yml
+++ b/gxformat2/examples/format2/synthetic-legacy-int-link.gxwf.yml
@@ -1,0 +1,13 @@
+class: GalaxyWorkflow
+doc: |
+  Legacy compat C: ``$link`` value as a YAML integer (``$link: 0``).
+  Old converter accepted; new pipeline must coerce to str before
+  source resolution.
+inputs:
+  myinput: data
+steps:
+  cat:
+    tool_id: cat1
+    state:
+      input1:
+        $link: 0

--- a/gxformat2/examples/format2/synthetic-legacy-list-source.gxwf.yml
+++ b/gxformat2/examples/format2/synthetic-legacy-list-source.gxwf.yml
@@ -1,0 +1,16 @@
+class: GalaxyWorkflow
+doc: |
+  Legacy compat F: dict-form ``in:`` value as a bare YAML list of source
+  references (multi-source input).  ``Sink.source`` already accepts
+  ``list[str]``; the case is rewritten to ``{source: [...]}`` in pre-pass
+  to satisfy strict pydantic validation.
+inputs:
+  input1: data
+  input2: data
+steps:
+  count_multi_file:
+    tool_id: count_multi_file
+    in:
+      input1:
+        - input1
+        - input2

--- a/gxformat2/examples/format2/synthetic-legacy-outputs-alias.gxwf.yml
+++ b/gxformat2/examples/format2/synthetic-legacy-outputs-alias.gxwf.yml
@@ -1,0 +1,15 @@
+class: GalaxyWorkflow
+doc: |
+  Legacy compat A: step-level ``outputs:`` is an alias for ``out:``.
+  Old gxformat2/converter.py accepted both; the rewrite drops it without
+  legacy_compat.  See gxformat2 issue #205.
+inputs:
+  input1: data
+steps:
+  cat:
+    tool_id: cat1
+    in:
+      input1: input1
+    outputs:
+      out_file1:
+        rename: renamed.txt

--- a/gxformat2/examples/format2/synthetic-legacy-step-form-input.gxwf.yml
+++ b/gxformat2/examples/format2/synthetic-legacy-step-form-input.gxwf.yml
@@ -1,0 +1,16 @@
+class: GalaxyWorkflow
+doc: |
+  Legacy compat B: ``type: input`` / ``input_collection`` declared as a
+  step entry must be lifted to the top-level ``inputs:`` map.  Old
+  gxformat2/converter.py did this via STEP_TYPE_ALIASES.
+steps:
+  myinput:
+    type: input
+    label: myinput
+  mycoll:
+    type: input_collection
+    label: mycoll
+  cat:
+    tool_id: cat1
+    in:
+      input1: myinput

--- a/gxformat2/normalized/_conversion.py
+++ b/gxformat2/normalized/_conversion.py
@@ -182,7 +182,11 @@ def _ensure_format2(resolved: dict[str, Any], options: ConversionOptions) -> Nor
     """Convert a fetched workflow dict to NormalizedFormat2, handling cross-format."""
     if resolved.get("a_galaxy_workflow") == "true":
         return to_format2(resolved, options=options, expand=False)
-    return normalized_format2(resolved, strict_structure=options.strict_structure)
+    return normalized_format2(
+        resolved,
+        strict_structure=options.strict_structure,
+        legacy_compat=options.legacy_compat,
+    )
 
 
 def _ensure_native(resolved: dict[str, Any], options: ConversionOptions) -> NormalizedNativeWorkflow:
@@ -272,13 +276,17 @@ def ensure_format2(
     if isinstance(workflow, NormalizedFormat2):
         result = workflow
     elif isinstance(workflow, GalaxyWorkflow):
-        result = normalized_format2(workflow, strict_structure=options.strict_structure)
+        result = normalized_format2(
+            workflow, strict_structure=options.strict_structure, legacy_compat=options.legacy_compat
+        )
     elif isinstance(workflow, (NativeGalaxyWorkflow, NormalizedNativeWorkflow)):
         result = to_format2(workflow, options=options, expand=False)
     elif isinstance(workflow, dict) and workflow.get("a_galaxy_workflow") == "true":
         result = to_format2(workflow, options=options, expand=False)
     else:
-        result = normalized_format2(workflow, strict_structure=options.strict_structure)
+        result = normalized_format2(
+            workflow, strict_structure=options.strict_structure, legacy_compat=options.legacy_compat
+        )
 
     if options.strict_structure:
         _validate_format2_output(result)
@@ -1028,7 +1036,9 @@ def to_native(
                 if graph_id == "main":
                     main_dict = entry
                 elif graph_id:
-                    sub_wf = normalized_format2(entry, strict_structure=options.strict_structure)
+                    sub_wf = normalized_format2(
+                        entry, strict_structure=options.strict_structure, legacy_compat=options.legacy_compat
+                    )
                     sub_ctx = _ConversionContext(options)
                     _register_labels(sub_wf, sub_ctx)
                     deduplicated_subworkflows[graph_id] = _build_native_workflow(sub_wf, sub_ctx)
@@ -1037,7 +1047,9 @@ def to_native(
             workflow = main_dict
 
     if not isinstance(workflow, NormalizedFormat2):
-        workflow = normalized_format2(workflow, strict_structure=options.strict_structure)
+        workflow = normalized_format2(
+            workflow, strict_structure=options.strict_structure, legacy_compat=options.legacy_compat
+        )
 
     ctx = _ConversionContext(options)
     _register_labels(workflow, ctx)

--- a/gxformat2/normalized/_format2.py
+++ b/gxformat2/normalized/_format2.py
@@ -41,6 +41,7 @@ from gxformat2.schema._input_parameter import input_parameter_class
 from gxformat2.schema.gxformat2_strict import GalaxyWorkflow as StrictGalaxyWorkflow
 from gxformat2.yaml import ordered_load_path
 
+from ._legacy_compat import apply_legacy_compat
 from ._types import ToolReference
 
 
@@ -227,6 +228,7 @@ def normalized_format2(
     workflow: dict[str, Any] | str | Path | os.PathLike[str] | GalaxyWorkflow,
     *,
     strict_structure: bool = False,
+    legacy_compat: bool = True,
 ) -> NormalizedFormat2:
     """Normalize a Format 2 Galaxy workflow into a fully typed model.
 
@@ -267,7 +269,9 @@ def normalized_format2(
             workflow = {**workflow, "outputs": {}}
         if "steps" not in workflow:
             workflow = {**workflow, "steps": {}}
-        workflow = _pre_clean_steps(workflow)
+        if legacy_compat:
+            workflow = apply_legacy_compat(workflow)
+        workflow = _pre_clean_steps(workflow, legacy_compat=legacy_compat)
         workflow = _pre_normalize_input_types(workflow)
         workflow = GalaxyWorkflow.model_validate(workflow)
     elif isinstance(workflow, GalaxyWorkflow) and strict_structure:
@@ -277,13 +281,22 @@ def normalized_format2(
         # recurse through the run union (which includes dict[str, Any]).
         StrictGalaxyWorkflow.model_validate(workflow.model_dump(by_alias=True, exclude_none=True))
     assert isinstance(workflow, GalaxyWorkflow)
-    return _normalize_workflow(workflow, strict_structure=strict_structure)
+    return _normalize_workflow(workflow, strict_structure=strict_structure, legacy_compat=legacy_compat)
 
 
-def _normalize_workflow(wf: GalaxyWorkflow, strict_structure: bool = False) -> NormalizedFormat2:
+def _normalize_workflow(
+    wf: GalaxyWorkflow,
+    strict_structure: bool = False,
+    legacy_compat: bool = True,
+) -> NormalizedFormat2:
     inputs = _normalize_inputs(wf.inputs)
     outputs = _normalize_outputs(wf.outputs)
-    steps = _normalize_steps(wf.steps, inputs_offset=len(inputs), strict_structure=strict_structure)
+    steps = _normalize_steps(
+        wf.steps,
+        inputs_offset=len(inputs),
+        strict_structure=strict_structure,
+        legacy_compat=legacy_compat,
+    )
     comments = _normalize_comments(wf.comments)
     doc = _join_doc(wf.doc)
 
@@ -430,7 +443,7 @@ def _pre_normalize_input_types(workflow: dict[str, Any]) -> dict[str, Any]:
     return {**workflow, "inputs": new_inputs}
 
 
-def _pre_clean_steps(workflow: dict[str, Any]) -> dict[str, Any]:
+def _pre_clean_steps(workflow: dict[str, Any], legacy_compat: bool = True) -> dict[str, Any]:
     """Resolve ``$link`` entries in step state dicts before model validation.
 
     ``$link`` in ``state`` is a Format2 shorthand for connections embedded in
@@ -440,22 +453,24 @@ def _pre_clean_steps(workflow: dict[str, Any]) -> dict[str, Any]:
     steps = workflow.get("steps", {})
     cleaned: dict[str, Any] | list[Any]
     if isinstance(steps, dict):
-        cleaned = {k: _pre_clean_step(v) if isinstance(v, dict) else v for k, v in steps.items()}
+        cleaned = {
+            k: _pre_clean_step(v, legacy_compat=legacy_compat) if isinstance(v, dict) else v for k, v in steps.items()
+        }
     elif isinstance(steps, list):
-        cleaned = [_pre_clean_step(s) if isinstance(s, dict) else s for s in steps]
+        cleaned = [_pre_clean_step(s, legacy_compat=legacy_compat) if isinstance(s, dict) else s for s in steps]
     else:
         return workflow
     return {**workflow, "steps": cleaned}
 
 
-def _pre_clean_step(step: dict[str, Any]) -> dict[str, Any]:
+def _pre_clean_step(step: dict[str, Any], legacy_compat: bool = True) -> dict[str, Any]:
     """Resolve $link in state on a single step dict."""
     state = step.get("state")
     if not isinstance(state, dict):
         # Recursively clean subworkflow runs even if no state
         run = step.get("run")
         if isinstance(run, dict) and run.get("class") == "GalaxyWorkflow":
-            return {**step, "run": _pre_clean_steps(run)}
+            return {**step, "run": _pre_clean_steps(run, legacy_compat=legacy_compat)}
         return step
 
     step = dict(step)
@@ -477,7 +492,7 @@ def _pre_clean_step(step: dict[str, Any]) -> dict[str, Any]:
     # Recursively clean subworkflow runs
     run = step.get("run")
     if isinstance(run, dict) and run.get("class") == "GalaxyWorkflow":
-        step["run"] = _pre_clean_steps(run)
+        step["run"] = _pre_clean_steps(run, legacy_compat=legacy_compat)
 
     return step
 
@@ -486,6 +501,7 @@ def _normalize_steps(
     steps: list[WorkflowStep] | dict[str, WorkflowStep],
     inputs_offset: int = 0,
     strict_structure: bool = False,
+    legacy_compat: bool = True,
 ) -> list[NormalizedWorkflowStep]:
     if isinstance(steps, dict):
         step_list = []
@@ -518,13 +534,15 @@ def _normalize_steps(
             else:
                 step_list.append(step)
 
-    return [_normalize_step(s, strict_structure=strict_structure) for s in step_list]
+    return [_normalize_step(s, strict_structure=strict_structure, legacy_compat=legacy_compat) for s in step_list]
 
 
 _CONNECTED_VALUE = {"__class__": "ConnectedValue"}
 
 
-def _normalize_step(step: WorkflowStep, strict_structure: bool = False) -> NormalizedWorkflowStep:
+def _normalize_step(
+    step: WorkflowStep, strict_structure: bool = False, legacy_compat: bool = True
+) -> NormalizedWorkflowStep:
     in_list = _normalize_step_inputs(step.in_)
     out_list = _normalize_step_outputs(step.out)
 
@@ -537,7 +555,7 @@ def _normalize_step(step: WorkflowStep, strict_structure: bool = False) -> Norma
         elif step.run.get("class") == "GalaxyUserTool":
             run = GalaxyUserToolStub.model_validate(step.run)
         else:
-            run = normalized_format2(step.run, strict_structure=strict_structure)
+            run = normalized_format2(step.run, strict_structure=strict_structure, legacy_compat=legacy_compat)
     elif isinstance(step.run, str):
         run = step.run
 
@@ -587,6 +605,8 @@ def _resolve_links(
 
     if isinstance(value, dict) and "$link" in value:
         link_value = value["$link"]
+        if isinstance(link_value, (int, float)) and not isinstance(link_value, bool):
+            link_value = str(link_value)
         connections.setdefault(key, []).append(link_value)
         return dict(_CONNECTED_VALUE), connections
 
@@ -602,6 +622,8 @@ def _resolve_links(
         for i, v in enumerate(value):
             if isinstance(v, dict) and "$link" in v:
                 link_value = v["$link"]
+                if isinstance(link_value, (int, float)) and not isinstance(link_value, bool):
+                    link_value = str(link_value)
                 connections.setdefault(key, []).append(link_value)
                 new_list.append(None)
             else:
@@ -614,7 +636,7 @@ def _resolve_links(
 
 
 def _normalize_step_inputs(
-    in_: list[WorkflowStepInput] | dict[str, WorkflowStepInput | str] | None,
+    in_: list[WorkflowStepInput] | dict[str, WorkflowStepInput | str | list[str]] | None,
 ) -> list[WorkflowStepInput]:
     if in_ is None:
         return []
@@ -625,6 +647,9 @@ def _normalize_step_inputs(
     for key, value in in_.items():
         if isinstance(value, str):
             # Shorthand: input_name: "source_step/output"
+            result.append(WorkflowStepInput(id=key, source=value))
+        elif isinstance(value, list):
+            # Shorthand (mapPredicate: source): bare list value is the multi-source.
             result.append(WorkflowStepInput(id=key, source=value))
         elif isinstance(value, WorkflowStepInput):
             if value.id is None:

--- a/gxformat2/normalized/_legacy_compat.py
+++ b/gxformat2/normalized/_legacy_compat.py
@@ -1,0 +1,164 @@
+"""Legacy compatibility pre-pass for Format2 workflow dicts.
+
+Restores aliases and shorthand forms that the pre-rewrite ``converter.py``
+accepted but the new normalize/validate pipeline drops or rejects. Gated
+by ``ConversionOptions.legacy_compat`` (default ``True``); a future major
+release can flip the default off.
+
+Covers:
+
+* **A** - step-level ``outputs:`` aliased to ``out:``.
+* **B** - step-form ``type: input``/``input_collection``/``parameter_input``
+  lifted into top-level ``inputs:``.
+* **D** - non-string ``tool_version`` (e.g. unquoted YAML float ``0.1``)
+  coerced to ``str``.
+
+C (int ``$link``) and F (bare-list dict-form ``in:`` value) were originally
+gated here but are bugs against the schema, not legacy aliases, and are
+fixed unconditionally elsewhere.
+
+Recurses into inline subworkflow ``run:`` dicts.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_INPUT_STEP_TYPES = {"input", "input_collection", "parameter_input"}
+
+
+def apply_legacy_compat(workflow: dict[str, Any]) -> dict[str, Any]:
+    """Apply A, B, D, F shims to a Format2 workflow dict in place-ish.
+
+    Returns a new dict; nested dicts may be shared with the input where no
+    rewrite was needed.
+    """
+    workflow = _lift_step_form_inputs(workflow)
+
+    steps = workflow.get("steps")
+    if isinstance(steps, dict):
+        cleaned: dict[str, Any] | list[Any] = {
+            k: _clean_step(v) if isinstance(v, dict) else v for k, v in steps.items()
+        }
+        workflow = {**workflow, "steps": cleaned}
+    elif isinstance(steps, list):
+        cleaned = [_clean_step(s) if isinstance(s, dict) else s for s in steps]
+        workflow = {**workflow, "steps": cleaned}
+
+    return workflow
+
+
+def _clean_step(step: dict[str, Any]) -> dict[str, Any]:
+    step = _alias_outputs_to_out(step)
+    step = _coerce_tool_version(step)
+
+    run = step.get("run")
+    if isinstance(run, dict) and run.get("class") == "GalaxyWorkflow":
+        step = {**step, "run": apply_legacy_compat(run)}
+
+    return step
+
+
+def _alias_outputs_to_out(step: dict[str, Any]) -> dict[str, Any]:
+    if "outputs" in step and "out" not in step:
+        step = {**step}
+        step["out"] = step.pop("outputs")
+    return step
+
+
+def _coerce_tool_version(step: dict[str, Any]) -> dict[str, Any]:
+    tv = step.get("tool_version")
+    if isinstance(tv, (int, float)) and not isinstance(tv, bool):
+        step = {**step, "tool_version": str(tv)}
+    return step
+
+
+def _lift_step_form_inputs(workflow: dict[str, Any]) -> dict[str, Any]:
+    """Move step entries with ``type: input`` (etc.) into top-level ``inputs:``."""
+    steps = workflow.get("steps")
+    inputs = workflow.get("inputs")
+
+    lifted: dict[str, Any] = {}
+    remaining_dict: dict[str, Any] | None = None
+    remaining_list: list[Any] | None = None
+
+    if isinstance(steps, dict):
+        remaining_dict = {}
+        for key, step in steps.items():
+            if isinstance(step, dict) and step.get("type") in _INPUT_STEP_TYPES:
+                lifted_key = step.get("label") or step.get("id") or key
+                lifted[str(lifted_key)] = _step_to_input(step)
+            else:
+                remaining_dict[key] = step
+    elif isinstance(steps, list):
+        remaining_list = []
+        for step in steps:
+            if isinstance(step, dict) and step.get("type") in _INPUT_STEP_TYPES:
+                lifted_key = step.get("label") or step.get("id")
+                if lifted_key is None:
+                    remaining_list.append(step)
+                    continue
+                lifted[str(lifted_key)] = _step_to_input(step)
+            else:
+                remaining_list.append(step)
+
+    if not lifted:
+        return workflow
+
+    new_workflow = dict(workflow)
+    if remaining_dict is not None:
+        new_workflow["steps"] = remaining_dict
+    elif remaining_list is not None:
+        new_workflow["steps"] = remaining_list
+
+    if isinstance(inputs, dict):
+        merged = {**lifted, **inputs}
+        new_workflow["inputs"] = merged
+    elif isinstance(inputs, list):
+        existing_keys = {entry.get("id") or entry.get("label") for entry in inputs if isinstance(entry, dict)}
+        extra = []
+        for k, v in lifted.items():
+            if k in existing_keys:
+                continue
+            extra.append({"id": k, **v})
+        new_workflow["inputs"] = extra + list(inputs)
+    else:
+        new_workflow["inputs"] = lifted
+
+    return new_workflow
+
+
+def _step_to_input(step: dict[str, Any]) -> dict[str, Any]:
+    """Strip step-only keys to leave a top-level input parameter dict."""
+    step_only = {
+        "id",
+        "label",
+        "type",
+        "position",
+        "tool_id",
+        "tool_version",
+        "in",
+        "out",
+        "run",
+        "state",
+        "tool_state",
+    }
+    raw_type = step.get("type")
+    type_alias = {
+        "input": "data",
+        "input_collection": "collection",
+        "parameter_input": None,
+    }
+    out: dict[str, Any] = {}
+    for k, v in step.items():
+        if k in step_only:
+            continue
+        out[k] = v
+    if raw_type == "parameter_input":
+        if "type" not in out and "parameter_type" in out:
+            out["type"] = out.pop("parameter_type")
+    elif raw_type in type_alias:
+        mapped = type_alias[raw_type]
+        if mapped is not None and "type" not in out:
+            out["type"] = mapped
+    return out

--- a/gxformat2/options.py
+++ b/gxformat2/options.py
@@ -57,6 +57,7 @@ class ConversionOptions:
         compact: bool = False,
         url_resolver: UrlResolverFn = None,
         strict_structure: bool = False,
+        legacy_compat: bool = True,
     ):
         self.workflow_directory = str(workflow_directory) if workflow_directory else None
         self.encode_tool_state_json = encode_tool_state_json
@@ -66,6 +67,7 @@ class ConversionOptions:
         self.compact = compact
         self.url_resolver = url_resolver
         self.strict_structure = strict_structure
+        self.legacy_compat = legacy_compat
 
 
 def default_url_resolver(url: str) -> dict[str, Any]:

--- a/gxformat2/schema/gxformat2.py
+++ b/gxformat2/schema/gxformat2.py
@@ -354,7 +354,7 @@ to representing `state` this way is defining inputs with default values."""
 
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 
-    in_: list[WorkflowStepInput] | dict[str, WorkflowStepInput | str] | None = Field(default=None, alias="in", description="Defines the input parameters of the workflow step.  The process is ready to run when all required input parameters are associated with concrete values.  Input parameters include a schema for each p...")
+    in_: list[WorkflowStepInput] | dict[str, WorkflowStepInput | str | list[str]] | None = Field(default=None, alias="in", description="Defines the input parameters of the workflow step.  The process is ready to run when all required input parameters are associated with concrete values.  Input parameters include a schema for each p...")
     out: list[WorkflowStepOutput | str] | dict[str, WorkflowStepOutput | str] | None = Field(default=None, description="Defines the parameters representing the output of the process.  May be used to generate and/or validate the output object.  This can also be called 'outputs' for legacy reasons - but the resulting ...")
     state: dict[str, Any] | None = Field(default=None, description="Structured tool state.")
     tool_state: str | dict[str, Any] | None = Field(default=None, description="Unstructured tool state.")

--- a/gxformat2/schema/gxformat2_strict.py
+++ b/gxformat2/schema/gxformat2_strict.py
@@ -354,7 +354,7 @@ to representing `state` this way is defining inputs with default values."""
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
-    in_: list[WorkflowStepInput] | dict[str, WorkflowStepInput | str] | None = Field(default=None, alias="in", description="Defines the input parameters of the workflow step.  The process is ready to run when all required input parameters are associated with concrete values.  Input parameters include a schema for each p...")
+    in_: list[WorkflowStepInput] | dict[str, WorkflowStepInput | str | list[str]] | None = Field(default=None, alias="in", description="Defines the input parameters of the workflow step.  The process is ready to run when all required input parameters are associated with concrete values.  Input parameters include a schema for each p...")
     out: list[WorkflowStepOutput | str] | dict[str, WorkflowStepOutput | str] | None = Field(default=None, description="Defines the parameters representing the output of the process.  May be used to generate and/or validate the output object.  This can also be called 'outputs' for legacy reasons - but the resulting ...")
     state: dict[str, Any] | None = Field(default=None, description="Structured tool state.")
     tool_state: str | dict[str, Any] | None = Field(default=None, description="Unstructured tool state.")

--- a/schema/v19_09/workflow.yml
+++ b/schema/v19_09/workflow.yml
@@ -356,7 +356,7 @@ $graph:
   fields:
     - name: in
       type:  WorkflowStepInput[]?
-      pydantic:type: "list[WorkflowStepInput] | dict[str, WorkflowStepInput | str] | None"
+      pydantic:type: "list[WorkflowStepInput] | dict[str, WorkflowStepInput | str | list[str]] | None"
       jsonldPredicate:
         _id: "gxformat2:in"
         mapSubject: id

--- a/tests/test_legacy_compat.py
+++ b/tests/test_legacy_compat.py
@@ -1,0 +1,47 @@
+"""Negative tests for ConversionOptions.legacy_compat=False (issue #205).
+
+When legacy_compat is off, the legacy aliases the pre-rewrite converter
+accepted are not normalized away.  Most produce a ValidationError; the
+``$link`` int case loses its source resolution silently.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from gxformat2.examples import load
+from gxformat2.normalized import normalized_format2
+
+
+def _lc_off(name: str):
+    return normalized_format2(load(name), legacy_compat=False)
+
+
+def test_outputs_alias_dropped_without_compat():
+    # extra="allow" keeps the key but _normalize_step never reads it
+    n = _lc_off("synthetic-legacy-outputs-alias.gxwf.yml")
+    assert n.steps[0].out == []
+
+
+def test_step_form_input_rejected_without_compat():
+    # ``type: input`` is not a valid WorkflowStepType -- pydantic rejects.
+    with pytest.raises(ValidationError):
+        _lc_off("synthetic-legacy-step-form-input.gxwf.yml")
+
+
+def test_int_link_still_works_without_compat():
+    # C is fixed unconditionally (schema bug, not legacy alias).
+    n = _lc_off("synthetic-legacy-int-link.gxwf.yml")
+    assert n.steps[0].in_[0].source == "0"
+
+
+def test_float_tool_version_rejected_without_compat():
+    with pytest.raises(ValidationError):
+        _lc_off("synthetic-legacy-float-tool-version.gxwf.yml")
+
+
+def test_list_source_still_works_without_compat():
+    # F is fixed unconditionally (schema permits the form via mapPredicate: source).
+    n = _lc_off("synthetic-legacy-list-source.gxwf.yml")
+    assert n.steps[0].in_[0].source == ["input1", "input2"]


### PR DESCRIPTION
Closes #205. Unblocks several failing tests tracked in #204; drives most of the test churn in galaxyproject/galaxy#22642 and galaxyproject/galaxy#22645.

## Summary

The 0.25→0.26 rewrite (move from `gxformat2/converter.py` to `gxformat2/normalized/_format2.py`) silently dropped several input aliases the old converter accepted explicitly. This adds a single pre-pass module gated by a new `ConversionOptions.legacy_compat` (default `True`) that restores them, plus fixes two related schema-vs-codegen bugs unconditionally.

## Behind the flag (legacy aliases)

- **A.** Step-level `outputs:` aliased to `out:`. Old converter did `step.pop("outputs", [])` with comment "Handle LEGACY 19.XX outputs key"; schema doc at `schema/v19_09/workflow.yml:384` still advertises the alias.
- **B.** Step-form `type: input` / `input_collection` / `parameter_input` lifted into top-level `inputs:`. Replaces the old `STEP_TYPE_ALIASES` / `transform_input` path.
- **D.** Non-string `tool_version` (e.g. unquoted YAML float `0.1`) coerced to `str`. Pydantic v2 doesn't auto-coerce `float` → `str`.

## Unconditional bug fixes (schema permitted, codegen rejected)

- **C.** Int/float `$link` values coerced to `str` in `_resolve_links`. `$link` isn't in the schema models — purely a Format2 pre-validation shorthand — and downstream resolution expects str.
- **F.** Bare-list dict-form `in:` value, e.g.:
  ```yaml
  in:
    input1:
      - foo/output
      - bar/output
  ```
  The schema permits this via `mapPredicate: source` + `Sink.source: string[]?`. The `pydantic:type` override at `schema/v19_09/workflow.yml:359` was too narrow — widened to include `list[str]` in the dict-value union, regenerated. Also added the missing `elif isinstance(value, list)` branch in `_normalize_step_inputs`.

## Tests

- 5 synthetic fixtures under `gxformat2/examples/format2/synthetic-legacy-*.gxwf.yml`
- 6 declarative expectations in `gxformat2/examples/expectations/legacy_compat.yml` (positive cases + one A→native PJA round-trip)
- `tests/test_legacy_compat.py`: 5 cases pinning behavior with `legacy_compat=False` (A/B/D raise or strip; C/F still work since they're unconditional)

668 passed, 8 skipped (was 657 + 8). ruff / black / mypy clean.

## Out of scope (separate issues)

- #206 — step-level `post_job_actions:` propagation (bug, not legacy)
- #207 — `default:` on step `in:` tool-state params not folded into native `tool_state` (bug, not legacy)
- Follow-up to be filed: hide all `$link` shorthand handling behind an option similar to `legacy_compat`