### PR TITLE
Propagate step-level post_job_actions through Format2 (closes #206)

### DIFF
--- a/gxformat2/examples/catalog.yml
+++ b/gxformat2/examples/catalog.yml
@@ -618,6 +618,8 @@
   tests:
     - tests/test_interop_tests.py
 
+# --- schema-vs-codegen mismatches (issue #205) ---
+
 - file: format2/synthetic-int-link.gxwf.yml
   origin: synthetic
   format: format2
@@ -629,5 +631,21 @@
   origin: synthetic
   format: format2
   description: "Dict-form in: value as a bare list of source references (mapPredicate shorthand for multi-source)."
+  tests:
+    - tests/test_interop_tests.py
+
+# --- post_job_actions fixtures (issue #206) ---
+
+- file: format2/synthetic-step-post-job-actions.gxwf.yml
+  origin: synthetic
+  format: format2
+  description: Step-level explicit post_job_actions map (ValidateOutputsAction).
+  tests:
+    - tests/test_interop_tests.py
+
+- file: format2/synthetic-step-post-job-actions-merged.gxwf.yml
+  origin: synthetic
+  format: format2
+  description: Step has both out:-shorthand and explicit post_job_actions; both flow to native.
   tests:
     - tests/test_interop_tests.py

--- a/gxformat2/examples/expectations/post_job_actions.yml
+++ b/gxformat2/examples/expectations/post_job_actions.yml
@@ -1,0 +1,31 @@
+test_step_post_job_actions_normalized:
+  fixture: synthetic-step-post-job-actions.gxwf.yml
+  operation: normalized_format2
+  assertions:
+    - path: [steps, 0, post_job_actions, ValidateOutputsAction, action_type]
+      value: ValidateOutputsAction
+
+test_step_post_job_actions_to_native:
+  fixture: synthetic-step-post-job-actions.gxwf.yml
+  operation: to_native
+  assertions:
+    - path: [steps, "1", post_job_actions, ValidateOutputsAction, action_type]
+      value: ValidateOutputsAction
+
+test_step_post_job_actions_round_trip:
+  fixture: synthetic-step-post-job-actions.gxwf.yml
+  operation: ensure_native
+  assertions:
+    - path: [steps, "1", post_job_actions, ValidateOutputsAction, action_type]
+      value: ValidateOutputsAction
+
+test_step_post_job_actions_merged_with_out_shorthand:
+  fixture: synthetic-step-post-job-actions-merged.gxwf.yml
+  operation: to_native
+  assertions:
+    - path: [steps, "1", post_job_actions, ValidateOutputsAction, action_type]
+      value: ValidateOutputsAction
+    - path: [steps, "1", post_job_actions, RenameDatasetActionout_file1, action_type]
+      value: RenameDatasetAction
+    - path: [steps, "1", post_job_actions, RenameDatasetActionout_file1, output_name]
+      value: out_file1

--- a/gxformat2/examples/format2/synthetic-step-post-job-actions-merged.gxwf.yml
+++ b/gxformat2/examples/format2/synthetic-step-post-job-actions-merged.gxwf.yml
@@ -1,0 +1,17 @@
+class: GalaxyWorkflow
+doc: |
+  Step has both an ``out:`` shorthand PJA (``rename:``) and an explicit
+  ``post_job_actions:`` entry — both should appear in the native step.
+inputs:
+  input1: data
+steps:
+  first_cat:
+    tool_id: cat1
+    in:
+      input1: input1
+    out:
+      out_file1:
+        rename: renamed.txt
+    post_job_actions:
+      ValidateOutputsAction:
+        action_type: ValidateOutputsAction

--- a/gxformat2/examples/format2/synthetic-step-post-job-actions.gxwf.yml
+++ b/gxformat2/examples/format2/synthetic-step-post-job-actions.gxwf.yml
@@ -1,0 +1,19 @@
+class: GalaxyWorkflow
+doc: |
+  Step-level explicit ``post_job_actions:`` map.  Cribbed from Galaxy's
+  ``test_validated_post_job_action_validated`` to exercise PJAs that have
+  no ``out:`` shorthand (``ValidateOutputsAction`` operates on the step
+  as a whole, not on a specific output).  See gxformat2 #206.
+inputs:
+  input1: data
+outputs:
+  wf_output_1:
+    outputSource: first_cat/out_file1
+steps:
+  first_cat:
+    tool_id: cat1
+    in:
+      input1: input1
+    post_job_actions:
+      ValidateOutputsAction:
+        action_type: ValidateOutputsAction

--- a/gxformat2/normalized/_conversion.py
+++ b/gxformat2/normalized/_conversion.py
@@ -582,7 +582,7 @@ def _build_tool_format2_step(
         return _build_user_tool_format2_step(step, label_map, options.compact)
 
     in_list = _build_format2_step_inputs(step, label_map)
-    out_list = _build_format2_step_outputs(step)
+    out_list, remaining_pjas = _build_format2_step_outputs(step)
 
     # Handle tool state
     state: dict[str, Any] | None = None
@@ -619,6 +619,7 @@ def _build_tool_format2_step(
         tool_state=tool_state,
         in_=in_list,
         out=out_list,
+        post_job_actions=remaining_pjas,
         position=_convert_position(step.position) if not options.compact else None,
         when=step.when,
         uuid=step.uuid,
@@ -632,7 +633,7 @@ def _build_user_tool_format2_step(
     compact: bool,
 ) -> NormalizedWorkflowStep:
     in_list = _build_format2_step_inputs(step, label_map)
-    out_list = _build_format2_step_outputs(step)
+    out_list, remaining_pjas = _build_format2_step_outputs(step)
     raw_label = step.label or label_map.get(str(step.id))
     step_id = raw_label or str(step.id)
 
@@ -643,6 +644,7 @@ def _build_user_tool_format2_step(
         run=GalaxyUserToolStub.model_validate(step.tool_representation) if step.tool_representation else None,
         in_=in_list,
         out=out_list,
+        post_job_actions=remaining_pjas,
         position=_convert_position(step.position) if not compact else None,
     )
 
@@ -653,7 +655,7 @@ def _build_subworkflow_format2_step(
     options: ConversionOptions,
 ) -> NormalizedWorkflowStep:
     in_list = _build_format2_step_inputs(step, label_map)
-    out_list = _build_format2_step_outputs(step)
+    out_list, remaining_pjas = _build_format2_step_outputs(step)
 
     run: NormalizedFormat2 | str | None = None
     content_source = step.content_source
@@ -675,6 +677,7 @@ def _build_subworkflow_format2_step(
         run=run,
         in_=in_list,
         out=out_list,
+        post_job_actions=remaining_pjas,
         position=_convert_position(step.position) if not options.compact else None,
         when=step.when,
         uuid=step.uuid,
@@ -708,7 +711,7 @@ def _build_pick_value_format2_step(
     options: ConversionOptions,
 ) -> NormalizedWorkflowStep:
     in_list = _build_format2_step_inputs(step, label_map)
-    out_list = _build_format2_step_outputs(step)
+    out_list, remaining_pjas = _build_format2_step_outputs(step)
 
     state: dict[str, Any] | None = None
     tool_state = step.tool_state
@@ -727,6 +730,7 @@ def _build_pick_value_format2_step(
         state=state,
         in_=in_list,
         out=out_list,
+        post_job_actions=remaining_pjas,
         position=_convert_position(step.position) if not compact else None,
     )
 
@@ -776,50 +780,61 @@ def _build_format2_step_inputs(
     return in_list
 
 
-def _build_format2_step_outputs(step: NormalizedNativeStep) -> list[WorkflowStepOutput]:
-    """Convert native post_job_actions to Format2 step outputs."""
+def _build_format2_step_outputs(
+    step: NormalizedNativeStep,
+) -> tuple[list[WorkflowStepOutput], dict[str, NativePostJobAction] | None]:
+    """Convert native post_job_actions to Format2 step outputs.
+
+    Returns ``(out_list, remaining_pjas)``: PJAs with a known ``out:``
+    shorthand are folded into output entries; everything else (including
+    actions like ``ValidateOutputsAction`` that have no output_name) is
+    returned as-is for the caller to surface on the Format2 step's
+    ``post_job_actions:`` field.
+    """
     if not step.post_job_actions:
-        return []
+        return [], None
 
     outputs_by_name: dict[str, dict[str, Any]] = {}
-    remaining_pjas: dict[str, Any] = {}
+    remaining_pjas: dict[str, NativePostJobAction] = {}
 
     for pja_key, pja in step.post_job_actions.items():
         action_type = pja.action_type
         output_name = pja.output_name
         action_args = pja.action_arguments or {}
 
-        if output_name not in outputs_by_name:
-            outputs_by_name[output_name] = {}
-        output_dict = outputs_by_name[output_name]
-
         handled = True
-        if action_type == "RenameDatasetAction":
-            output_dict["rename"] = action_args["newname"]
-        elif action_type == "HideDatasetAction":
-            output_dict["hide"] = True
-        elif action_type == "DeleteIntermediatesAction":
-            output_dict["delete_intermediate_datasets"] = True
-        elif action_type == "ChangeDatatypeAction":
-            output_dict["change_datatype"] = action_args["newtype"]
-        elif action_type == "TagDatasetAction":
-            output_dict["add_tags"] = action_args["tags"].split(",")
-        elif action_type == "RemoveTagDatasetAction":
-            output_dict["remove_tags"] = action_args["tags"].split(",")
-        elif action_type == "ColumnSetAction":
-            if action_args:
-                output_dict["set_columns"] = action_args
+        if output_name is not None:
+            output_dict = outputs_by_name.setdefault(output_name, {})
+            if action_type == "RenameDatasetAction":
+                output_dict["rename"] = action_args["newname"]
+            elif action_type == "HideDatasetAction":
+                output_dict["hide"] = True
+            elif action_type == "DeleteIntermediatesAction":
+                output_dict["delete_intermediate_datasets"] = True
+            elif action_type == "ChangeDatatypeAction":
+                output_dict["change_datatype"] = action_args["newtype"]
+            elif action_type == "TagDatasetAction":
+                output_dict["add_tags"] = action_args["tags"].split(",")
+            elif action_type == "RemoveTagDatasetAction":
+                output_dict["remove_tags"] = action_args["tags"].split(",")
+            elif action_type == "ColumnSetAction":
+                if action_args:
+                    output_dict["set_columns"] = action_args
+            else:
+                handled = False
+                if not output_dict:
+                    outputs_by_name.pop(output_name, None)
         else:
             handled = False
 
         if not handled:
-            remaining_pjas[pja_key] = pja.model_dump(by_alias=True, exclude_none=True)
+            remaining_pjas[pja_key] = pja
 
     result: list[WorkflowStepOutput] = []
     for name, props in outputs_by_name.items():
         result.append(WorkflowStepOutput(id=name, **props))
 
-    return result
+    return result, (remaining_pjas or None)
 
 
 def _to_source(output_name: str, label_map: dict[str, str], step_id: int) -> str:
@@ -1299,7 +1314,7 @@ def _build_tool_step(
     input_connections = _build_input_connections(connect, ctx, is_subworkflow=False)
 
     # Build post job actions
-    post_job_actions = _build_post_job_actions(step.out)
+    post_job_actions = _build_post_job_actions(step.out, step.post_job_actions)
 
     position = _default_position(step.position, order_index)
 
@@ -1352,7 +1367,7 @@ def _build_subworkflow_step(
     input_connections = _build_input_connections(
         connect, ctx, is_subworkflow=is_subworkflow, subworkflow_ctx=subworkflow_child_ctx
     )
-    post_job_actions = _build_post_job_actions(step.out)
+    post_job_actions = _build_post_job_actions(step.out, step.post_job_actions)
     position = _default_position(step.position, order_index)
 
     return NormalizedNativeStep(
@@ -1411,7 +1426,7 @@ def _build_pick_value_step(
     if num_inputs > 0:
         tool_state["num_inputs"] = max(2, num_inputs)
 
-    post_job_actions = _build_post_job_actions(step.out)
+    post_job_actions = _build_post_job_actions(step.out, step.post_job_actions)
     position = _default_position(step.position, order_index)
 
     return NormalizedNativeStep(
@@ -1482,6 +1497,7 @@ def _build_input_connections(
 
 def _build_post_job_actions(
     outputs: list[WorkflowStepOutput],
+    explicit: dict[str, NativePostJobAction] | None = None,
 ) -> dict[str, NativePostJobAction]:
     post_job_actions: dict[str, NativePostJobAction] = {}
     for output in outputs:
@@ -1500,6 +1516,10 @@ def _build_post_job_actions(
                     output_name=output_name,
                     action_arguments=action_dict["arguments"](action_value),
                 )
+    if explicit:
+        # Explicit step.post_job_actions wins over out:-shorthand-derived entries
+        # for keys that collide; otherwise merged.
+        post_job_actions.update(explicit)
     return post_job_actions
 
 

--- a/gxformat2/normalized/_conversion.py
+++ b/gxformat2/normalized/_conversion.py
@@ -823,7 +823,7 @@ def _build_format2_step_outputs(
             else:
                 handled = False
                 if not output_dict:
-                    outputs_by_name.pop(output_name, None)
+                    del outputs_by_name[output_name]
         else:
             handled = False
 

--- a/gxformat2/normalized/_format2.py
+++ b/gxformat2/normalized/_format2.py
@@ -39,6 +39,7 @@ from gxformat2.schema.gxformat2 import (
 )
 from gxformat2.schema._input_parameter import input_parameter_class
 from gxformat2.schema.gxformat2_strict import GalaxyWorkflow as StrictGalaxyWorkflow
+from gxformat2.schema.native import NativePostJobAction
 from gxformat2.yaml import ordered_load_path
 
 from ._types import ToolReference
@@ -130,6 +131,10 @@ class NormalizedWorkflowStep(_DictMixin, BaseModel):
         default_factory=list, alias="in", description="Always a list, shorthands expanded."
     )
     out: list[WorkflowStepOutput] = Field(default_factory=list, description="Always a list, shorthands expanded.")
+    post_job_actions: dict[str, NativePostJobAction] | None = Field(
+        default=None,
+        description="Explicit post-job actions keyed by ``{ActionType}{OutputName}`` compound strings.",
+    )
     run: NormalizedFormat2 | GalaxyUserToolStub | ImportReference | str | None = Field(default=None)
 
     @field_validator("run", mode="before")
@@ -568,8 +573,23 @@ def _normalize_step(step: WorkflowStep, strict_structure: bool = False) -> Norma
         errors=step.errors,
         uuid=step.uuid,
         out=out_list,
+        post_job_actions=_normalize_post_job_actions(step.post_job_actions),
         run=run,
     )
+
+
+def _normalize_post_job_actions(
+    raw: dict[str, Any] | None,
+) -> dict[str, NativePostJobAction] | None:
+    """Validate raw PJA dict-of-dicts into typed records.
+
+    Galaxy emits explicit ``post_job_actions:`` as plain mapping; the schema
+    field is ``Any?`` to keep the raw model lax.  Coerce here so downstream
+    code (lint, conversion) sees the same typed shape as the native side.
+    """
+    if not raw:
+        return None
+    return {key: NativePostJobAction.model_validate(value) for key, value in raw.items()}
 
 
 def _resolve_links(

--- a/gxformat2/schema/gxformat2.py
+++ b/gxformat2/schema/gxformat2.py
@@ -358,6 +358,7 @@ to representing `state` this way is defining inputs with default values."""
     out: list[WorkflowStepOutput | str] | dict[str, WorkflowStepOutput | str] | None = Field(default=None, description="Defines the parameters representing the output of the process.  May be used to generate and/or validate the output object.  This can also be called 'outputs' for legacy reasons - but the resulting ...")
     state: dict[str, Any] | None = Field(default=None, description="Structured tool state.")
     tool_state: str | dict[str, Any] | None = Field(default=None, description="Unstructured tool state.")
+    post_job_actions: dict[str, Any] | None = Field(default=None, description="Optional dict of post-job actions keyed by ``{ActionType}{OutputName}`` compound strings.  Same shape as the native ``post_job_actions`` field; each value is a record with ``action_type``, ``output...")
     type_: None | WorkflowStepType = Field(default=None, alias="type", description="Workflow step module's type (defaults to 'tool').")
     run: GalaxyWorkflow | str | dict[str, Any] | None = Field(default=None, description="Specifies a subworkflow to run. May be an inline workflow definition, a URL string, or an @import reference dict.")
     runtime_inputs: None | list[str] = Field(default=None)

--- a/gxformat2/schema/gxformat2_strict.py
+++ b/gxformat2/schema/gxformat2_strict.py
@@ -358,6 +358,7 @@ to representing `state` this way is defining inputs with default values."""
     out: list[WorkflowStepOutput | str] | dict[str, WorkflowStepOutput | str] | None = Field(default=None, description="Defines the parameters representing the output of the process.  May be used to generate and/or validate the output object.  This can also be called 'outputs' for legacy reasons - but the resulting ...")
     state: dict[str, Any] | None = Field(default=None, description="Structured tool state.")
     tool_state: str | dict[str, Any] | None = Field(default=None, description="Unstructured tool state.")
+    post_job_actions: dict[str, Any] | None = Field(default=None, description="Optional dict of post-job actions keyed by ``{ActionType}{OutputName}`` compound strings.  Same shape as the native ``post_job_actions`` field; each value is a record with ``action_type``, ``output...")
     type_: None | WorkflowStepType = Field(default=None, alias="type", description="Workflow step module's type (defaults to 'tool').")
     run: GalaxyWorkflow | str | dict[str, Any] | None = Field(default=None, description="Specifies a subworkflow to run. May be an inline workflow definition, a URL string, or an @import reference dict.")
     runtime_inputs: None | list[str] = Field(default=None)

--- a/gxformat2/schema/native.py
+++ b/gxformat2/schema/native.py
@@ -198,7 +198,7 @@ Common action types: ``HideDatasetAction``, ``RenameDatasetAction``,
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 
     action_type: str = Field(description="The action type identifier (e.g. ``HideDatasetAction``).")
-    output_name: str = Field(description="The step output this action applies to.")
+    output_name: str | None = Field(default=None, description="The step output this action applies to.  Optional: action types that operate on the step as a whole (e.g. ``ValidateOutputsAction``) omit this field.")
     action_arguments: dict[str, Any] | None = Field(default=None, description="Action-specific arguments. For ``RenameDatasetAction``: ``{\"newname\": \"...\"}``; for ``ChangeDatatypeAction``: ``{\"newtype\": \"tabular\"}``; for ``TagDatasetAction``: ``{\"tags\": \"name:tag\"...")
 
 class NativeTextCommentData(BaseModel):

--- a/gxformat2/schema/native_strict.py
+++ b/gxformat2/schema/native_strict.py
@@ -198,7 +198,7 @@ Common action types: ``HideDatasetAction``, ``RenameDatasetAction``,
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
     action_type: str = Field(description="The action type identifier (e.g. ``HideDatasetAction``).")
-    output_name: str = Field(description="The step output this action applies to.")
+    output_name: str | None = Field(default=None, description="The step output this action applies to.  Optional: action types that operate on the step as a whole (e.g. ``ValidateOutputsAction``) omit this field.")
     action_arguments: dict[str, Any] | None = Field(default=None, description="Action-specific arguments. For ``RenameDatasetAction``: ``{\"newname\": \"...\"}``; for ``ChangeDatatypeAction``: ``{\"newtype\": \"tabular\"}``; for ``TagDatasetAction``: ``{\"tags\": \"name:tag\"...")
 
 class NativeTextCommentData(BaseModel):

--- a/gxformat2/schema/native_v0_1.py
+++ b/gxformat2/schema/native_v0_1.py
@@ -3677,54 +3677,53 @@ class NativePostJobAction(Saveable):
                             "is not valid because:",
                         )
                     )
-        try:
-            if _doc.get("output_name") is None:
-                raise ValidationException("missing required field `output_name`", None, [])
-
-            output_name = load_field(
-                _doc.get("output_name"),
-                strtype,
-                baseuri,
-                loadingOptions,
-                lc=_doc.get("output_name")
-            )
-
-        except ValidationException as e:
-            error_message, to_print, verb_tensage = parse_errors(str(e))
-
-            if str(e) == "missing required field `output_name`":
-                _errors__.append(
-                    ValidationException(
-                        str(e),
-                        None
-                    )
+        output_name = None
+        if "output_name" in _doc:
+            try:
+                output_name = load_field(
+                    _doc.get("output_name"),
+                    union_of_strtype_or_None_type,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("output_name")
                 )
-            else:
-                val = _doc.get("output_name")
-                if error_message != str(e):
-                    val_type = convert_typing(extract_type(type(val)))
+
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `output_name`":
                     _errors__.append(
                         ValidationException(
-                            "the `output_name` field is not valid because:",
-                            SourceLine(_doc, "output_name", str),
-                            [ValidationException(f"Value is a {val_type}, "
-                                                 f"but valid {to_print} for this field "
-                                                 f"{verb_tensage} {error_message}",
-                                                 detailed_message=f"Value `{val}` is a {val_type}, "
-                                                 f"but valid {to_print} for this field "
-                                                 f"{verb_tensage} {error_message}")],
+                            str(e),
+                            None
                         )
                     )
                 else:
-                    _errors__.append(
-                        ValidationException(
-                            "the `output_name` field is not valid because:",
-                            SourceLine(_doc, "output_name", str),
-                            [e],
-                            detailed_message=f"the `output_name` field with value `{val}` "
-                            "is not valid because:",
+                    val = _doc.get("output_name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `output_name` field is not valid because:",
+                                SourceLine(_doc, "output_name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
                         )
-                    )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `output_name` field is not valid because:",
+                                SourceLine(_doc, "output_name", str),
+                                [e],
+                                detailed_message=f"the `output_name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
         action_arguments = None
         if "action_arguments" in _doc:
             try:
@@ -11766,6 +11765,12 @@ union_of_None_type_or_inttype = _UnionLoader(
     (
         None_type,
         inttype,
+    )
+)
+union_of_strtype_or_None_type = _UnionLoader(
+    (
+        strtype,
+        None_type,
     )
 )
 union_of_None_type_or_Any_type = _UnionLoader(

--- a/gxformat2/schema/v19_09.py
+++ b/gxformat2/schema/v19_09.py
@@ -8380,6 +8380,7 @@ class WorkflowStep(
         in_: Optional[Any] = None,
         state: Optional[Any] = None,
         tool_state: Optional[Any] = None,
+        post_job_actions: Optional[Any] = None,
         type_: Optional[Any] = None,
         run: Optional[Any] = None,
         runtime_inputs: Optional[Any] = None,
@@ -8408,6 +8409,7 @@ class WorkflowStep(
         self.out = out
         self.state = state
         self.tool_state = tool_state
+        self.post_job_actions = post_job_actions
         self.type_ = type_
         self.run = run
         self.runtime_inputs = runtime_inputs
@@ -8429,6 +8431,7 @@ class WorkflowStep(
                 and self.out == other.out
                 and self.state == other.state
                 and self.tool_state == other.tool_state
+                and self.post_job_actions == other.post_job_actions
                 and self.type_ == other.type_
                 and self.run == other.run
                 and self.runtime_inputs == other.runtime_inputs
@@ -8452,6 +8455,7 @@ class WorkflowStep(
                 self.out,
                 self.state,
                 self.tool_state,
+                self.post_job_actions,
                 self.type_,
                 self.run,
                 self.runtime_inputs,
@@ -9093,6 +9097,53 @@ class WorkflowStep(
                                 "is not valid because:",
                             )
                         )
+        post_job_actions = None
+        if "post_job_actions" in _doc:
+            try:
+                post_job_actions = load_field(
+                    _doc.get("post_job_actions"),
+                    union_of_None_type_or_Any_type,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("post_job_actions")
+                )
+
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `post_job_actions`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("post_job_actions")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `post_job_actions` field is not valid because:",
+                                SourceLine(_doc, "post_job_actions", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `post_job_actions` field is not valid because:",
+                                SourceLine(_doc, "post_job_actions", str),
+                                [e],
+                                detailed_message=f"the `post_job_actions` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
         type_ = None
         if "type" in _doc:
             try:
@@ -9298,7 +9349,7 @@ class WorkflowStep(
                 else:
                     _errors__.append(
                         ValidationException(
-                            "invalid field `{}`, expected one of: `id`, `label`, `doc`, `position`, `tool_id`, `tool_shed_repository`, `tool_version`, `errors`, `uuid`, `in`, `out`, `state`, `tool_state`, `type`, `run`, `runtime_inputs`, `when`".format(
+                            "invalid field `{}`, expected one of: `id`, `label`, `doc`, `position`, `tool_id`, `tool_shed_repository`, `tool_version`, `errors`, `uuid`, `in`, `out`, `state`, `tool_state`, `post_job_actions`, `type`, `run`, `runtime_inputs`, `when`".format(
                                 k
                             ),
                             SourceLine(_doc, k, str),
@@ -9321,6 +9372,7 @@ class WorkflowStep(
             out=out,
             state=state,
             tool_state=tool_state,
+            post_job_actions=post_job_actions,
             type_=type_,
             run=run,
             runtime_inputs=runtime_inputs,
@@ -9402,6 +9454,13 @@ class WorkflowStep(
                 base_url=self.id,
                 relative_uris=relative_uris,
             )
+        if self.post_job_actions is not None:
+            r["post_job_actions"] = save(
+                self.post_job_actions,
+                top=False,
+                base_url=self.id,
+                relative_uris=relative_uris,
+            )
         if self.type_ is not None:
             r["type"] = save(
                 self.type_, top=False, base_url=self.id, relative_uris=relative_uris
@@ -9444,6 +9503,7 @@ class WorkflowStep(
             "out",
             "state",
             "tool_state",
+            "post_job_actions",
             "type",
             "run",
             "runtime_inputs",

--- a/schema/native_v0_1/workflow.yml
+++ b/schema/native_v0_1/workflow.yml
@@ -153,11 +153,15 @@ $graph:
       doc: |
         The action type identifier (e.g. ``HideDatasetAction``).
     - name: output_name
-      type: string
+      type:
+        - string
+        - "null"
       jsonldPredicate:
         _id: "gxnative:output_name"
       doc: |
-        The step output this action applies to.
+        The step output this action applies to.  Optional: action types that
+        operate on the step as a whole (e.g. ``ValidateOutputsAction``) omit
+        this field.
     - name: action_arguments
       type: Any?
       pydantic:type: "dict[str, Any] | None"

--- a/schema/v19_09/workflow.yml
+++ b/schema/v19_09/workflow.yml
@@ -399,6 +399,21 @@ $graph:
         noLinkCheck: true
       doc: |
         Unstructured tool state.
+    - name: post_job_actions
+      type: Any?
+      pydantic:type: "dict[str, Any] | None"
+      jsonldPredicate:
+        _id: "gxformat2:post_job_actions"
+        noLinkCheck: true
+      doc: |
+        Optional dict of post-job actions keyed by ``{ActionType}{OutputName}``
+        compound strings.  Same shape as the native ``post_job_actions`` field;
+        each value is a record with ``action_type``, ``output_name``,
+        ``action_arguments``.  Use the ``out:`` shorthand (``rename:``,
+        ``hide:``, ``change_datatype:``, etc.) for common actions; this
+        explicit form covers actions without an ``out:`` shorthand
+        (``ValidateOutputsAction``, etc.) and any case where the typed
+        record is preferred.
     - name: type
       type: WorkflowStepType?
       jsonldPredicate:


### PR DESCRIPTION
Closes #206. Unblocks `test_validated_post_job_action_validated` and `test_validated_post_job_action_invalid` (#204).

## Problem

Format2 step-level `post_job_actions:` was silently dropped during conversion:

```yaml
steps:
  first_cat:
    tool_id: cat1
    in:
      input1: input1
    post_job_actions:
      ValidateOutputsAction:
        action_type: ValidateOutputsAction
```

`WorkflowStep` had no `post_job_actions` field; `extra=\"allow\"` kept the key on the model but no code read it. `_build_post_job_actions(step.out)` only consumed `out:` shorthand entries.

## Fix

**Forward (Format2 → native):**
- `WorkflowStep` (Format2 schema) gains a `post_job_actions: Any?` field with `pydantic:type: \"dict[str, Any] | None\"` — Galaxy emits dicts, raw model stays lax.
- `NormalizedWorkflowStep` gains `post_job_actions: dict[str, NativePostJobAction] | None` — normalize validates the raw dict-of-dicts into typed records.
- `_build_post_job_actions(step.out, explicit=...)` merges explicit PJAs on top of `out:`-shorthand-derived entries; explicit wins on key collision.

**Reverse (native → Format2):**
- `_build_format2_step_outputs` now returns `(out_list, remaining_pjas)`. PJAs without an `out:` shorthand (e.g. `ValidateOutputsAction`, which has no `output_name`) round-trip back through the explicit `post_job_actions:` field instead of being silently discarded. All four call sites (tool / user-tool / subworkflow / pick_value step builders) updated.

**Schema fix:**
- `NativePostJobAction.output_name` made optional. Action types that operate on the step as a whole (e.g. `ValidateOutputsAction`) omit it; the schema previously required it but Galaxy never emitted it.

## Tests

- `synthetic-step-post-job-actions.gxwf.yml` — minimal repro from the failing Galaxy test
- `synthetic-step-post-job-actions-merged.gxwf.yml` — explicit + `out:` shorthand coexist
- 4 declarative expectations under `gxformat2/examples/expectations/post_job_actions.yml`:
  - normalize preserves PJAs
  - to_native propagates PJAs
  - native→Format2→native round-trips PJAs without `out:` shorthand
  - merged shorthand + explicit both flow to native

661 passed (657 → 661), 8 skipped. ruff / black / mypy clean.

## Out of scope

- #205 (legacy_compat aliases) — separate PR
- #207 (`default:` on step `in:` tool-state params) — separate