### PR TITLE
Accept bare-list multi-source and integer $link in Format2 dicts

### DIFF
--- a/gxformat2/examples/catalog.yml
+++ b/gxformat2/examples/catalog.yml
@@ -617,3 +617,17 @@
   description: List-form steps without labels — triggers "no label" warning.
   tests:
     - tests/test_interop_tests.py
+
+- file: format2/synthetic-int-link.gxwf.yml
+  origin: synthetic
+  format: format2
+  description: $link value as a YAML integer; coerced to str during source resolution.
+  tests:
+    - tests/test_interop_tests.py
+
+- file: format2/synthetic-multisource-bare-list.gxwf.yml
+  origin: synthetic
+  format: format2
+  description: "Dict-form in: value as a bare list of source references (mapPredicate shorthand for multi-source)."
+  tests:
+    - tests/test_interop_tests.py

--- a/gxformat2/examples/expectations/normalized_format2.yml
+++ b/gxformat2/examples/expectations/normalized_format2.yml
@@ -155,3 +155,27 @@ test_link_resolved_to_connected_value:
       value: ConnectedValue
     - path: [steps, {id: nested_workflow}, run, steps, 0, in_, {id: input}, source]
       value: inner_input
+
+test_int_link_coerced_to_str:
+  fixture: synthetic-int-link.gxwf.yml
+  operation: normalized_format2
+  assertions:
+    - path: [steps, 0, in_, $length]
+      value: 1
+    - path: [steps, 0, in_, 0, id]
+      value: input1
+    - path: [steps, 0, in_, 0, source]
+      value: "0"
+
+test_multisource_bare_list:
+  fixture: synthetic-multisource-bare-list.gxwf.yml
+  operation: normalized_format2
+  assertions:
+    - path: [steps, 0, in_, $length]
+      value: 1
+    - path: [steps, 0, in_, 0, id]
+      value: input1
+    - path: [steps, 0, in_, 0, source]
+      value:
+        - input1
+        - input2

--- a/gxformat2/examples/format2/synthetic-int-link.gxwf.yml
+++ b/gxformat2/examples/format2/synthetic-int-link.gxwf.yml
@@ -1,0 +1,13 @@
+class: GalaxyWorkflow
+doc: |
+  ``$link`` value parsed by YAML as an integer (e.g. ``$link: 0``). The
+  resolver expects a string source reference, so unquoted-numeric values
+  are coerced before source resolution.
+inputs:
+  myinput: data
+steps:
+  cat:
+    tool_id: cat1
+    state:
+      input1:
+        $link: 0

--- a/gxformat2/examples/format2/synthetic-multisource-bare-list.gxwf.yml
+++ b/gxformat2/examples/format2/synthetic-multisource-bare-list.gxwf.yml
@@ -1,0 +1,15 @@
+class: GalaxyWorkflow
+doc: |
+  Dict-form ``in:`` value as a bare YAML list of source references for a
+  multi-source input. The schema's ``mapPredicate: source`` shorthand
+  permits this and ``Sink.source`` accepts ``list[str]``.
+inputs:
+  input1: data
+  input2: data
+steps:
+  count_multi_file:
+    tool_id: count_multi_file
+    in:
+      input1:
+        - input1
+        - input2

--- a/gxformat2/normalized/_format2.py
+++ b/gxformat2/normalized/_format2.py
@@ -587,6 +587,8 @@ def _resolve_links(
 
     if isinstance(value, dict) and "$link" in value:
         link_value = value["$link"]
+        if isinstance(link_value, int) and not isinstance(link_value, bool):
+            link_value = str(link_value)
         connections.setdefault(key, []).append(link_value)
         return dict(_CONNECTED_VALUE), connections
 
@@ -602,6 +604,8 @@ def _resolve_links(
         for i, v in enumerate(value):
             if isinstance(v, dict) and "$link" in v:
                 link_value = v["$link"]
+                if isinstance(link_value, int) and not isinstance(link_value, bool):
+                    link_value = str(link_value)
                 connections.setdefault(key, []).append(link_value)
                 new_list.append(None)
             else:
@@ -614,7 +618,7 @@ def _resolve_links(
 
 
 def _normalize_step_inputs(
-    in_: list[WorkflowStepInput] | dict[str, WorkflowStepInput | str] | None,
+    in_: list[WorkflowStepInput] | dict[str, WorkflowStepInput | str | list[str]] | None,
 ) -> list[WorkflowStepInput]:
     if in_ is None:
         return []
@@ -625,6 +629,9 @@ def _normalize_step_inputs(
     for key, value in in_.items():
         if isinstance(value, str):
             # Shorthand: input_name: "source_step/output"
+            result.append(WorkflowStepInput(id=key, source=value))
+        elif isinstance(value, list):
+            # Shorthand (mapPredicate: source): bare list value is the multi-source.
             result.append(WorkflowStepInput(id=key, source=value))
         elif isinstance(value, WorkflowStepInput):
             if value.id is None:

--- a/gxformat2/schema/gxformat2.py
+++ b/gxformat2/schema/gxformat2.py
@@ -354,7 +354,7 @@ to representing `state` this way is defining inputs with default values."""
 
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 
-    in_: list[WorkflowStepInput] | dict[str, WorkflowStepInput | str] | None = Field(default=None, alias="in", description="Defines the input parameters of the workflow step.  The process is ready to run when all required input parameters are associated with concrete values.  Input parameters include a schema for each p...")
+    in_: list[WorkflowStepInput] | dict[str, WorkflowStepInput | str | list[str]] | None = Field(default=None, alias="in", description="Defines the input parameters of the workflow step.  The process is ready to run when all required input parameters are associated with concrete values.  Input parameters include a schema for each p...")
     out: list[WorkflowStepOutput | str] | dict[str, WorkflowStepOutput | str] | None = Field(default=None, description="Defines the parameters representing the output of the process.  May be used to generate and/or validate the output object.  This can also be called 'outputs' for legacy reasons - but the resulting ...")
     state: dict[str, Any] | None = Field(default=None, description="Structured tool state.")
     tool_state: str | dict[str, Any] | None = Field(default=None, description="Unstructured tool state.")

--- a/gxformat2/schema/gxformat2_strict.py
+++ b/gxformat2/schema/gxformat2_strict.py
@@ -354,7 +354,7 @@ to representing `state` this way is defining inputs with default values."""
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
-    in_: list[WorkflowStepInput] | dict[str, WorkflowStepInput | str] | None = Field(default=None, alias="in", description="Defines the input parameters of the workflow step.  The process is ready to run when all required input parameters are associated with concrete values.  Input parameters include a schema for each p...")
+    in_: list[WorkflowStepInput] | dict[str, WorkflowStepInput | str | list[str]] | None = Field(default=None, alias="in", description="Defines the input parameters of the workflow step.  The process is ready to run when all required input parameters are associated with concrete values.  Input parameters include a schema for each p...")
     out: list[WorkflowStepOutput | str] | dict[str, WorkflowStepOutput | str] | None = Field(default=None, description="Defines the parameters representing the output of the process.  May be used to generate and/or validate the output object.  This can also be called 'outputs' for legacy reasons - but the resulting ...")
     state: dict[str, Any] | None = Field(default=None, description="Structured tool state.")
     tool_state: str | dict[str, Any] | None = Field(default=None, description="Unstructured tool state.")

--- a/schema/v19_09/workflow.yml
+++ b/schema/v19_09/workflow.yml
@@ -356,7 +356,7 @@ $graph:
   fields:
     - name: in
       type:  WorkflowStepInput[]?
-      pydantic:type: "list[WorkflowStepInput] | dict[str, WorkflowStepInput | str] | None"
+      pydantic:type: "list[WorkflowStepInput] | dict[str, WorkflowStepInput | str | list[str]] | None"
       jsonldPredicate:
         _id: "gxformat2:in"
         mapSubject: id


### PR DESCRIPTION
Refs #205. Replaces #208.

Two schema-vs-codegen mismatches surfaced after the 0.25 → 0.26 normalize/validate rewrite tightened pydantic validation.

## Changes

**Dict-form `in:` value as a bare YAML list of source references**

```yaml
steps:
  count:
    in:
      input1:
        - input1
        - input2
```

The schema permits this via `mapPredicate: source` plus `Sink.source: string[]?`, but the `pydantic:type` override at `schema/v19_09/workflow.yml:359` was too narrow. Widened the dict-value union to include `list[str]`, regenerated, and added the missing `list` branch in `_normalize_step_inputs`.

**Integer `\$link` values**

```yaml
state:
  input1:
    \$link: 0
```

`\$link` is a Format2 pre-validation shorthand (not in the pydantic models) and downstream source resolution expects a string. Unquoted numeric values now coerce to str inside `_resolve_links`.

## Tests

Two synthetic fixtures + declarative cases in `expectations/normalized_format2.yml`. Full suite: 659 passed, 8 skipped. ruff / flake8 / black / mypy clean.

## Why this was carved out of #208

#208 also bundled a `legacy_compat` flag restoring three older Format2 forms (step-level `outputs:` aliased to `out:`, step-form `type: input` lifted to top-level `inputs:`, unquoted-numeric `tool_version` coerced to str). Per review (@nsoranzo): the first two have best-practice alternatives and Galaxy's tests have already been updated; the third is a YAML quoting issue users should fix. Dropped the shim entirely. This PR is just the two schema/codegen bug fixes that have no best-practice alternative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)