### PR TITLE
Propagate step input defaults through Format2

### DIFF
--- a/gxformat2/examples/catalog.yml
+++ b/gxformat2/examples/catalog.yml
@@ -649,3 +649,19 @@
   description: Step has both out:-shorthand and explicit post_job_actions; both flow to native.
   tests:
     - tests/test_interop_tests.py
+
+# --- step-input default fixtures (issue #207) ---
+
+- file: format2/synthetic-step-input-default-scalar.gxwf.yml
+  origin: synthetic
+  format: format2
+  description: "Tool step with scalar tool-state defaults via in/param/default."
+  tests:
+    - tests/test_interop_tests.py
+
+- file: format2/synthetic-step-input-default-file.gxwf.yml
+  origin: synthetic
+  format: format2
+  description: "Tool step with an inline File-class default via in/input1/default."
+  tests:
+    - tests/test_interop_tests.py

--- a/gxformat2/examples/expectations/to_native.yml
+++ b/gxformat2/examples/expectations/to_native.yml
@@ -149,3 +149,31 @@ test_to_native_comments_dict:
   assertions:
     - path: [comments, $length]
       value: 3
+
+test_to_native_step_input_default_scalar:
+  fixture: synthetic-step-input-default-scalar.gxwf.yml
+  operation: to_native
+  assertions:
+    - path: [steps, "1", type_]
+      value: tool
+    - path: [steps, "1", tool_id]
+      value: random_lines1
+    - path: [steps, "1", in_,num_lines, default]
+      value: 2
+    - path: [steps, "1", in_,"seed_source|seed_source_selector", default]
+      value: set_seed
+    - path: [steps, "1", in_,"seed_source|seed", default]
+      value: asdf
+
+test_to_native_step_input_default_file:
+  fixture: synthetic-step-input-default-file.gxwf.yml
+  operation: to_native
+  assertions:
+    - path: [steps, "0", type_]
+      value: tool
+    - path: [steps, "0", tool_id]
+      value: cat1
+    - path: [steps, "0", in_,input1, default, class]
+      value: File
+    - path: [steps, "0", in_,input1, default, basename]
+      value: a file

--- a/gxformat2/examples/format2/synthetic-step-input-default-file.gxwf.yml
+++ b/gxformat2/examples/format2/synthetic-step-input-default-file.gxwf.yml
@@ -1,0 +1,11 @@
+class: GalaxyWorkflow
+steps:
+  cat1:
+    tool_id: cat1
+    in:
+      input1:
+        default:
+          class: File
+          basename: a file
+          format: txt
+          location: https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/1.bed

--- a/gxformat2/examples/format2/synthetic-step-input-default-scalar.gxwf.yml
+++ b/gxformat2/examples/format2/synthetic-step-input-default-scalar.gxwf.yml
@@ -1,0 +1,14 @@
+class: GalaxyWorkflow
+inputs:
+  inner_input: data
+steps:
+  random_lines:
+    tool_id: random_lines1
+    in:
+      input: inner_input
+      num_lines:
+        default: 2
+      seed_source|seed_source_selector:
+        default: set_seed
+      seed_source|seed:
+        default: asdf

--- a/gxformat2/normalized/_conversion.py
+++ b/gxformat2/normalized/_conversion.py
@@ -1335,6 +1335,7 @@ def _build_tool_step(
         when=step.when,
         uuid=step.uuid,
         errors=step.errors,
+        in_=_extract_step_in_defaults(step),
     )
 
 
@@ -1383,6 +1384,7 @@ def _build_subworkflow_step(
         position=position,
         when=step.when,
         uuid=step.uuid,
+        in_=_extract_step_in_defaults(step),
     )
 
 
@@ -1462,6 +1464,27 @@ def _extract_connections(step: NormalizedWorkflowStep) -> dict[str, list]:
             else:
                 connect[input_id] = [source]
     return connect
+
+
+def _extract_step_in_defaults(step: NormalizedWorkflowStep) -> dict[str, Any] | None:
+    """Collect ``in: {param: {default: ...}}`` entries for native ``step["in"]``.
+
+    Galaxy reads ``step_dict["in"][name]["default"]`` to seed
+    ``WorkflowStepInput.default_value`` (see
+    ``galaxy.managers.workflows`` ``__module_from_dict``). Format2 surfaces
+    these as ``WorkflowStepInput.default`` on the normalized step; keep them
+    on the native side so tool-state defaults and File-class defaults are
+    not lost.
+    """
+    in_defaults: dict[str, Any] = {}
+    for step_input in step.in_:
+        input_id = step_input.id
+        if input_id is None:
+            continue
+        if step_input.default is None:
+            continue
+        in_defaults[input_id] = {"default": step_input.default}
+    return in_defaults or None
 
 
 def _build_input_connections(

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -100,6 +100,76 @@ steps:
     }
 
 
+def test_step_input_default_file_inline_to_native():
+    as_dict_native = to_native("""
+class: GalaxyWorkflow
+steps:
+  cat1:
+    tool_id: cat1
+    in:
+      input1:
+        default:
+          class: File
+          basename: a file
+          format: txt
+          location: test.txt
+""")
+    cat_step = as_dict_native["steps"]["0"]
+    assert cat_step["tool_id"] == "cat1"
+    assert cat_step["in"]["input1"]["default"] == {
+        "class": "File",
+        "basename": "a file",
+        "format": "txt",
+        "location": "test.txt",
+    }
+
+
+def test_step_input_default_scalar_to_native():
+    as_dict_native = to_native("""
+class: GalaxyWorkflow
+inputs:
+  inner_input: data
+steps:
+  random_lines:
+    tool_id: random_lines1
+    in:
+      input: inner_input
+      num_lines:
+        default: 2
+      seed_source|seed_source_selector:
+        default: set_seed
+      seed_source|seed:
+        default: asdf
+""")
+    rl_step = as_dict_native["steps"]["1"]
+    assert rl_step["tool_id"] == "random_lines1"
+    assert rl_step["in"]["num_lines"] == {"default": 2}
+    assert rl_step["in"]["seed_source|seed_source_selector"] == {"default": "set_seed"}
+    assert rl_step["in"]["seed_source|seed"] == {"default": "asdf"}
+
+
+def test_step_input_default_round_trip():
+    fmt2 = round_trip("""
+class: GalaxyWorkflow
+inputs:
+  inner_input: data
+steps:
+  random_lines:
+    tool_id: random_lines1
+    in:
+      input: inner_input
+      num_lines:
+        default: 2
+""")
+    step = fmt2["steps"]["random_lines"]
+    in_entries = {entry["id"]: entry for entry in step["in"]} if isinstance(step["in"], list) else step["in"]
+    num_lines_entry = in_entries["num_lines"]
+    if isinstance(num_lines_entry, dict):
+        assert num_lines_entry.get("default") == 2
+    else:
+        assert num_lines_entry == 2
+
+
 def test_docs_round_trip():
     as_dict = round_trip("""
 class: GalaxyWorkflow


### PR DESCRIPTION
## Summary

Fixes #207. Format2 `in: {param: {default: ...}}` entries on tool/subworkflow steps were dropped during `to_native` — only `source` connections survived. Galaxy reads `step_dict['in'][name]['default']` to seed `WorkflowStepInput.default_value`, so inline File-class defaults (`WORKFLOW_WITH_STEP_DEFAULT_FILE_DATASET_INPUT`) and scalar tool-state defaults (`random_lines` num_lines/seed_source case from `test_subworkflow_recover_mapping_2`) need to round-trip via the native step's `in` field.

Fix: emit `step.in_ = {input_id: {default: value}}` for each `WorkflowStepInput` with a non-None default, in `_build_tool_step` and `_build_subworkflow_step`. Export side already round-trips defaults out of `step.in_`.

## Test plan

- [x] New unit tests in `tests/test_basic.py` for inline File default, scalar tool-state defaults, and Format2→native→Format2 round-trip
- [x] Declarative expectations + fixtures (`synthetic-step-input-default-{scalar,file}.gxwf.yml`)
- [x] Full test suite passes (`uv run --group test pytest tests/`)
- [x] ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)