### PR TITLE
Model `fields` on workflow record inputs (closes #214)

### DIFF
--- a/gxformat2/_semantic_validators.py
+++ b/gxformat2/_semantic_validators.py
@@ -16,6 +16,7 @@ import re
 from typing import Any, Iterable, Mapping
 
 _COLUMN_NAME_RE = re.compile(r"^[\w\-_ \?]*$")
+_RECORD_RANK_RE = re.compile(r"(?:^|:)record(?::|$)")
 
 _TEXT_TYPE_VALUES = {"text", "string"}
 _COLLECTION_TYPE_VALUES = {"collection", "data_collection", "data_collection_input"}
@@ -103,6 +104,14 @@ def validate_input_parameter(input_param: Any) -> None:
             )
         for column in column_definitions:
             validate_column_definition(column)
+
+    fields = data.get("fields")
+    if fields:
+        if not is_collection_only and type_values:
+            raise ValueError(f"fields is only valid on collection inputs, got type={type_value!r}")
+        collection_type = data.get("collection_type") or ""
+        if not _RECORD_RANK_RE.search(collection_type):
+            raise ValueError(f"fields requires collection_type containing 'record', got {collection_type!r}")
 
     text_only_fields = ("restrictions", "suggestions", "restrictOnConnections")
     for field in text_only_fields:

--- a/gxformat2/examples/catalog.yml
+++ b/gxformat2/examples/catalog.yml
@@ -454,6 +454,19 @@
   tests:
     - tests/test_interop_tests.py
 
+- file: format2/synthetic-record-input.gxwf.yml
+  origin: synthetic
+  format: format2
+  tests:
+    - tests/test_basic.py
+    - tests/test_interop_tests.py
+
+- file: format2/synthetic-bad-fields-on-list.gxwf.yml
+  origin: synthetic
+  format: format2
+  tests:
+    - tests/test_interop_tests.py
+
 - file: format2/synthetic-comments-dict.gxwf.yml
   origin: synthetic
   format: format2

--- a/gxformat2/examples/expectations/normalized_inputs.yml
+++ b/gxformat2/examples/expectations/normalized_inputs.yml
@@ -43,6 +43,34 @@ test_paired_list_collection_type:
     - path: [inputs, 0, collection_type]
       value: "list:paired"
 
+test_record_collection_type_and_fields:
+  fixture: synthetic-record-input.gxwf.yml
+  operation: normalized_format2
+  assertions:
+    - path: [inputs, 0, collection_type]
+      value: record
+    - path: [inputs, 0, fields, $length]
+      value: 2
+    - path: [inputs, 0, fields, 0, name]
+      value: parent
+    - path: [inputs, 0, fields, 0, type_]
+      value: File
+    - path: [inputs, 0, fields, 1, name]
+      value: child
+    - path: [inputs, 0, fields, 1, type_]
+      value: ["File", "null"]
+
+test_record_fields_round_trip_to_native:
+  fixture: synthetic-record-input.gxwf.yml
+  operation: to_native
+  assertions:
+    - path: [steps, "0", tool_state, fields, $length]
+      value: 2
+    - path: [steps, "0", tool_state, fields, 0, name]
+      value: parent
+    - path: [steps, "0", tool_state, fields, 1, type]
+      value: ["File", "null"]
+
 test_sample_sheet_collection_type:
   fixture: synthetic-sample-sheet-input.gxwf.yml
   operation: normalized_format2

--- a/gxformat2/examples/expectations/validate_format2.yml
+++ b/gxformat2/examples/expectations/validate_format2.yml
@@ -359,6 +359,24 @@ test_column_default_mismatch_rejected_format2_strict:
   operation: validate_format2_strict
   expect_error: true
 
+test_record_input_valid_format2:
+  fixture: synthetic-record-input.gxwf.yml
+  operation: validate_format2
+
+test_record_input_valid_format2_strict:
+  fixture: synthetic-record-input.gxwf.yml
+  operation: validate_format2_strict
+
+test_fields_on_list_rejected_format2:
+  fixture: synthetic-bad-fields-on-list.gxwf.yml
+  operation: validate_format2
+  expect_error: true
+
+test_fields_on_list_rejected_format2_strict:
+  fixture: synthetic-bad-fields-on-list.gxwf.yml
+  operation: validate_format2_strict
+  expect_error: true
+
 test_comments_dict_valid_format2:
   fixture: synthetic-comments-dict.gxwf.yml
   operation: validate_format2

--- a/gxformat2/examples/format2/synthetic-bad-fields-on-list.gxwf.yml
+++ b/gxformat2/examples/format2/synthetic-bad-fields-on-list.gxwf.yml
@@ -1,0 +1,10 @@
+class: GalaxyWorkflow
+inputs:
+  bad:
+    type: collection
+    collection_type: list
+    fields:
+      - name: parent
+        type: File
+outputs: {}
+steps: {}

--- a/gxformat2/examples/format2/synthetic-record-input.gxwf.yml
+++ b/gxformat2/examples/format2/synthetic-record-input.gxwf.yml
@@ -1,0 +1,14 @@
+class: GalaxyWorkflow
+inputs:
+  input_record:
+    type: collection
+    collection_type: record
+    fields:
+      - name: parent
+        type: File
+      - name: child
+        type:
+          - File
+          - "null"
+outputs: {}
+steps: {}

--- a/gxformat2/normalized/_conversion.py
+++ b/gxformat2/normalized/_conversion.py
@@ -1194,11 +1194,8 @@ def _build_input_step(
     if inp.default is not None:
         tool_state["default"] = inp.default
 
-    # Copy text-parameter / sample-sheet fields. Most live on the typed model
-    # now (restrictions / suggestions / restrictOnConnections / column_definitions),
-    # but legacy / unmodelled keys (e.g. `fields`) may still arrive via
-    # ``model_extra``.
-    for key in ("restrictions", "suggestions", "restrictOnConnections", "column_definitions"):
+    # Copy text-parameter / sample-sheet / record fields from the typed model.
+    for key in ("restrictions", "suggestions", "restrictOnConnections", "column_definitions", "fields"):
         value = getattr(inp, key, None)
         if value is None:
             continue
@@ -1210,10 +1207,6 @@ def _build_input_step(
             tool_state[key] = value.model_dump(by_alias=True, exclude_none=True)
         else:
             tool_state[key] = value
-    if inp.model_extra:
-        for key in ("fields",):
-            if key in inp.model_extra:
-                tool_state[key] = inp.model_extra[key]
 
     position = _default_position(inp.position, order_index)
 

--- a/gxformat2/schema/gxformat2.py
+++ b/gxformat2/schema/gxformat2.py
@@ -207,6 +207,19 @@ workflow input."""
     restrictions: None | list[str | int | float | bool] = Field(default=None, description="Closed set of permitted values for this column. Item type must be compatible with the column `type` (post-validated).")
     suggestions: None | list[str | int | float | bool] = Field(default=None, description="Open suggestion list for this column.")
 
+class RecordFieldDefinition(BaseModel):
+    """Describes one field of a `record` collection input.
+Used in `fields` on a `collection_type` containing `record` (e.g.
+`record`, `list:record`, `sample_sheet:record`). Mirrors a subset of
+the CWL `InputRecordSchema` shape that Galaxy persists on
+`DatasetCollection.fields`."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    name: str = Field(description="Field name. Must equal the corresponding element identifier in the materialized record collection.")
+    type_: Literal["File", "null", "boolean", "int", "float", "string"] | list[Literal["File", "null", "boolean", "int", "float", "string"]] = Field(default="File", alias="type", description="Field value type. A subset of the CWL primitive types: `File`, `null`, `boolean`, `int`, `float`, `string`. May be a list to express a union (e.g. `[\"File\", \"null\"]` for an optional file).")
+    format: None | str = Field(default=None, description="Optional Galaxy datatype hint for `File`-typed fields.")
+
 class WorkflowTextOption(BaseModel):
     """A `{value, label}` option used in `restrictions` or `suggestions` on a
 text workflow parameter. Plain strings are also accepted in those
@@ -273,6 +286,7 @@ class WorkflowCollectionParameter(BaseDataParameter):
     type_: Literal["collection"] = Field(default="collection", alias="type", description="Must be ``collection``.")
     collection_type: None | str = Field(default=None, description="Collection type (defaults to `list` if `type` is `collection`). Nested collection types are separated with colons, e.g. `list:list:paired`.")
     column_definitions: None | list[SampleSheetColumnDefinition] = Field(default=None, description="Column schema for sample-sheet collection inputs. Only meaningful when `collection_type` begins with `sample_sheet` - cross-field validation is applied in the pydantic post-validator.")
+    fields: None | list[RecordFieldDefinition] = Field(default=None, description="Field schema for `record` collection inputs. Only meaningful when `collection_type` contains `record` (e.g. `record`, `list:record`, `sample_sheet:record`).")
 
 class MinMax(BaseModel):
     model_config = ConfigDict(populate_by_name=True, extra="allow")
@@ -351,6 +365,7 @@ of the specific parameter types instead."""
     type_: GalaxyType | None | list[GalaxyType] = Field(default=None, alias="type", description="Specify valid types of data that may be assigned to this parameter.")
     collection_type: None | str = Field(default=None, description="Collection type (defaults to `list` if `type` is `collection`). Nested collection types are separated with colons, e.g. `list:list:paired`.")
     column_definitions: None | list[SampleSheetColumnDefinition] = Field(default=None, description="Column schema for sample-sheet collection inputs. Only meaningful when `collection_type` begins with `sample_sheet`.")
+    fields: None | list[RecordFieldDefinition] = Field(default=None, description="Field schema for `record` collection inputs. Only meaningful when `collection_type` contains `record`.")
     restrictions: None | list[str | WorkflowTextOption] = Field(default=None, description="Closed set of permitted values for text-typed inputs. See `WorkflowTextParameter.restrictions`.")
     suggestions: None | list[str | WorkflowTextOption] = Field(default=None, description="Open suggestion list for text-typed inputs.")
     restrictOnConnections: None | bool = Field(default=None, description="For text-typed inputs - derive runtime choices from connected tool/subworkflow select inputs.")
@@ -569,6 +584,7 @@ HasStepPosition.model_rebuild()
 StepPosition.model_rebuild()
 ReferencesTool.model_rebuild()
 SampleSheetColumnDefinition.model_rebuild()
+RecordFieldDefinition.model_rebuild()
 WorkflowTextOption.model_rebuild()
 ToolShedRepository.model_rebuild()
 BaseInputParameter.model_rebuild()
@@ -610,3 +626,30 @@ def load_document(path: str | Path) -> GalaxyWorkflow | list[GalaxyWorkflow]:
 def _load_single(data: dict[str, Any]) -> GalaxyWorkflow:
     """Load a single document dict."""
     return GalaxyWorkflow.model_validate(data)
+
+
+_INPUT_TYPE_TO_CLASS: dict[str, type[BaseInputParameter]] = {
+    "data": WorkflowDataParameter,
+    "File": WorkflowDataParameter,
+    "data_input": WorkflowDataParameter,
+    "collection": WorkflowCollectionParameter,
+    "data_collection": WorkflowCollectionParameter,
+    "data_collection_input": WorkflowCollectionParameter,
+    "integer": WorkflowIntegerParameter,
+    "int": WorkflowIntegerParameter,
+    "text": WorkflowTextParameter,
+    "string": WorkflowTextParameter,
+    "float": WorkflowFloatParameter,
+    "boolean": WorkflowBooleanParameter,
+    "color": WorkflowTextParameter,
+}
+
+
+def input_parameter_class(type_value: str | None) -> type[BaseInputParameter]:
+    """Return the specific input parameter class for a Format2 type string.
+
+    Falls back to WorkflowDataParameter for unknown or None types.
+    """
+    if type_value is None:
+        return WorkflowDataParameter
+    return _INPUT_TYPE_TO_CLASS.get(type_value, WorkflowDataParameter)

--- a/gxformat2/schema/gxformat2_strict.py
+++ b/gxformat2/schema/gxformat2_strict.py
@@ -207,6 +207,19 @@ workflow input."""
     restrictions: None | list[str | int | float | bool] = Field(default=None, description="Closed set of permitted values for this column. Item type must be compatible with the column `type` (post-validated).")
     suggestions: None | list[str | int | float | bool] = Field(default=None, description="Open suggestion list for this column.")
 
+class RecordFieldDefinition(BaseModel):
+    """Describes one field of a `record` collection input.
+Used in `fields` on a `collection_type` containing `record` (e.g.
+`record`, `list:record`, `sample_sheet:record`). Mirrors a subset of
+the CWL `InputRecordSchema` shape that Galaxy persists on
+`DatasetCollection.fields`."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    name: str = Field(description="Field name. Must equal the corresponding element identifier in the materialized record collection.")
+    type_: Literal["File", "null", "boolean", "int", "float", "string"] | list[Literal["File", "null", "boolean", "int", "float", "string"]] = Field(default="File", alias="type", description="Field value type. A subset of the CWL primitive types: `File`, `null`, `boolean`, `int`, `float`, `string`. May be a list to express a union (e.g. `[\"File\", \"null\"]` for an optional file).")
+    format: None | str = Field(default=None, description="Optional Galaxy datatype hint for `File`-typed fields.")
+
 class WorkflowTextOption(BaseModel):
     """A `{value, label}` option used in `restrictions` or `suggestions` on a
 text workflow parameter. Plain strings are also accepted in those
@@ -273,6 +286,7 @@ class WorkflowCollectionParameter(BaseDataParameter):
     type_: Literal["collection"] = Field(default="collection", alias="type", description="Must be ``collection``.")
     collection_type: None | str = Field(default=None, description="Collection type (defaults to `list` if `type` is `collection`). Nested collection types are separated with colons, e.g. `list:list:paired`.")
     column_definitions: None | list[SampleSheetColumnDefinition] = Field(default=None, description="Column schema for sample-sheet collection inputs. Only meaningful when `collection_type` begins with `sample_sheet` - cross-field validation is applied in the pydantic post-validator.")
+    fields: None | list[RecordFieldDefinition] = Field(default=None, description="Field schema for `record` collection inputs. Only meaningful when `collection_type` contains `record` (e.g. `record`, `list:record`, `sample_sheet:record`).")
 
 class MinMax(BaseModel):
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
@@ -351,6 +365,7 @@ of the specific parameter types instead."""
     type_: GalaxyType | None | list[GalaxyType] = Field(default=None, alias="type", description="Specify valid types of data that may be assigned to this parameter.")
     collection_type: None | str = Field(default=None, description="Collection type (defaults to `list` if `type` is `collection`). Nested collection types are separated with colons, e.g. `list:list:paired`.")
     column_definitions: None | list[SampleSheetColumnDefinition] = Field(default=None, description="Column schema for sample-sheet collection inputs. Only meaningful when `collection_type` begins with `sample_sheet`.")
+    fields: None | list[RecordFieldDefinition] = Field(default=None, description="Field schema for `record` collection inputs. Only meaningful when `collection_type` contains `record`.")
     restrictions: None | list[str | WorkflowTextOption] = Field(default=None, description="Closed set of permitted values for text-typed inputs. See `WorkflowTextParameter.restrictions`.")
     suggestions: None | list[str | WorkflowTextOption] = Field(default=None, description="Open suggestion list for text-typed inputs.")
     restrictOnConnections: None | bool = Field(default=None, description="For text-typed inputs - derive runtime choices from connected tool/subworkflow select inputs.")
@@ -569,6 +584,7 @@ HasStepPosition.model_rebuild()
 StepPosition.model_rebuild()
 ReferencesTool.model_rebuild()
 SampleSheetColumnDefinition.model_rebuild()
+RecordFieldDefinition.model_rebuild()
 WorkflowTextOption.model_rebuild()
 ToolShedRepository.model_rebuild()
 BaseInputParameter.model_rebuild()

--- a/gxformat2/schema/native.py
+++ b/gxformat2/schema/native.py
@@ -153,6 +153,19 @@ workflow input."""
     restrictions: None | list[str | int | float | bool] = Field(default=None, description="Closed set of permitted values for this column. Item type must be compatible with the column `type` (post-validated).")
     suggestions: None | list[str | int | float | bool] = Field(default=None, description="Open suggestion list for this column.")
 
+class RecordFieldDefinition(BaseModel):
+    """Describes one field of a `record` collection input.
+Used in `fields` on a `collection_type` containing `record` (e.g.
+`record`, `list:record`, `sample_sheet:record`). Mirrors a subset of
+the CWL `InputRecordSchema` shape that Galaxy persists on
+`DatasetCollection.fields`."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    name: str = Field(description="Field name. Must equal the corresponding element identifier in the materialized record collection.")
+    type_: Literal["File", "null", "boolean", "int", "float", "string"] | list[Literal["File", "null", "boolean", "int", "float", "string"]] = Field(default="File", alias="type", description="Field value type. A subset of the CWL primitive types: `File`, `null`, `boolean`, `int`, `float`, `string`. May be a list to express a union (e.g. `[\"File\", \"null\"]` for an optional file).")
+    format: None | str = Field(default=None, description="Optional Galaxy datatype hint for `File`-typed fields.")
+
 class WorkflowTextOption(BaseModel):
     """A `{value, label}` option used in `restrictions` or `suggestions` on a
 text workflow parameter. Plain strings are also accepted in those
@@ -449,6 +462,7 @@ HasStepPosition.model_rebuild()
 StepPosition.model_rebuild()
 ReferencesTool.model_rebuild()
 SampleSheetColumnDefinition.model_rebuild()
+RecordFieldDefinition.model_rebuild()
 WorkflowTextOption.model_rebuild()
 ToolShedRepository.model_rebuild()
 NativeStepInput.model_rebuild()

--- a/gxformat2/schema/native_strict.py
+++ b/gxformat2/schema/native_strict.py
@@ -153,6 +153,19 @@ workflow input."""
     restrictions: None | list[str | int | float | bool] = Field(default=None, description="Closed set of permitted values for this column. Item type must be compatible with the column `type` (post-validated).")
     suggestions: None | list[str | int | float | bool] = Field(default=None, description="Open suggestion list for this column.")
 
+class RecordFieldDefinition(BaseModel):
+    """Describes one field of a `record` collection input.
+Used in `fields` on a `collection_type` containing `record` (e.g.
+`record`, `list:record`, `sample_sheet:record`). Mirrors a subset of
+the CWL `InputRecordSchema` shape that Galaxy persists on
+`DatasetCollection.fields`."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    name: str = Field(description="Field name. Must equal the corresponding element identifier in the materialized record collection.")
+    type_: Literal["File", "null", "boolean", "int", "float", "string"] | list[Literal["File", "null", "boolean", "int", "float", "string"]] = Field(default="File", alias="type", description="Field value type. A subset of the CWL primitive types: `File`, `null`, `boolean`, `int`, `float`, `string`. May be a list to express a union (e.g. `[\"File\", \"null\"]` for an optional file).")
+    format: None | str = Field(default=None, description="Optional Galaxy datatype hint for `File`-typed fields.")
+
 class WorkflowTextOption(BaseModel):
     """A `{value, label}` option used in `restrictions` or `suggestions` on a
 text workflow parameter. Plain strings are also accepted in those
@@ -449,6 +462,7 @@ HasStepPosition.model_rebuild()
 StepPosition.model_rebuild()
 ReferencesTool.model_rebuild()
 SampleSheetColumnDefinition.model_rebuild()
+RecordFieldDefinition.model_rebuild()
 WorkflowTextOption.model_rebuild()
 ToolShedRepository.model_rebuild()
 NativeStepInput.model_rebuild()

--- a/gxformat2/schema/native_v0_1.py
+++ b/gxformat2/schema/native_v0_1.py
@@ -2857,6 +2857,283 @@ class SampleSheetColumnDefinition(Saveable):
     )
 
 
+class RecordFieldDefinition(Saveable):
+    """
+    Describes one field of a `record` collection input.
+    Used in `fields` on a `collection_type` containing `record` (e.g.
+    `record`, `list:record`, `sample_sheet:record`). Mirrors a subset of
+    the CWL `InputRecordSchema` shape that Galaxy persists on
+    `DatasetCollection.fields`.
+
+    """
+
+    name: str
+
+    def __init__(
+        self,
+        name: Any,
+        type_: Any,
+        format: Optional[Any] = None,
+        extension_fields: Optional[dict[str, Any]] = None,
+        loadingOptions: Optional[LoadingOptions] = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+        self.type_ = type_
+        self.format = format
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, RecordFieldDefinition):
+            return bool(
+                self.name == other.name
+                and self.type_ == other.type_
+                and self.format == other.format
+            )
+        return False
+
+    def __hash__(self) -> int:
+        return hash((self.name, self.type_, self.format))
+
+    @classmethod
+    def fromDoc(
+        cls,
+        doc: Any,
+        baseuri: str,
+        loadingOptions: LoadingOptions,
+        docRoot: Optional[str] = None
+    ) -> "RecordFieldDefinition":
+        _doc = copy.copy(doc)
+
+        if hasattr(doc, "lc"):
+            _doc.lc.data = doc.lc.data
+            _doc.lc.filename = doc.lc.filename
+        _errors__ = []
+        name = None
+        if "name" in _doc:
+            try:
+                name = load_field(
+                    _doc.get("name"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
+
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
+        __original_name_is_none = name is None
+        if name is None:
+            if docRoot is not None:
+                name = docRoot
+            else:
+                _errors__.append(ValidationException("missing name"))
+        if not __original_name_is_none:
+            baseuri = cast(str, name)
+        try:
+            if _doc.get("type") is None:
+                raise ValidationException("missing required field `type`", None, [])
+
+            type_ = load_field(
+                _doc.get("type"),
+                typedsl_union_of_strtype_or_array_of_strtype_2,
+                baseuri,
+                loadingOptions,
+                lc=_doc.get("type")
+            )
+
+        except ValidationException as e:
+            error_message, to_print, verb_tensage = parse_errors(str(e))
+
+            if str(e) == "missing required field `type`":
+                _errors__.append(
+                    ValidationException(
+                        str(e),
+                        None
+                    )
+                )
+            else:
+                val = _doc.get("type")
+                if error_message != str(e):
+                    val_type = convert_typing(extract_type(type(val)))
+                    _errors__.append(
+                        ValidationException(
+                            "the `type` field is not valid because:",
+                            SourceLine(_doc, "type", str),
+                            [ValidationException(f"Value is a {val_type}, "
+                                                 f"but valid {to_print} for this field "
+                                                 f"{verb_tensage} {error_message}",
+                                                 detailed_message=f"Value `{val}` is a {val_type}, "
+                                                 f"but valid {to_print} for this field "
+                                                 f"{verb_tensage} {error_message}")],
+                        )
+                    )
+                else:
+                    _errors__.append(
+                        ValidationException(
+                            "the `type` field is not valid because:",
+                            SourceLine(_doc, "type", str),
+                            [e],
+                            detailed_message=f"the `type` field with value `{val}` "
+                            "is not valid because:",
+                        )
+                    )
+        format = None
+        if "format" in _doc:
+            try:
+                format = load_field(
+                    _doc.get("format"),
+                    union_of_None_type_or_strtype,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("format")
+                )
+
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `format`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("format")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `format` field is not valid because:",
+                                SourceLine(_doc, "format", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `format` field is not valid because:",
+                                SourceLine(_doc, "format", str),
+                                [e],
+                                detailed_message=f"the `format` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+        extension_fields: dict[str, Any] = {}
+        for k in _doc.keys():
+            if k not in cls.attrs:
+                if not k:
+                    _errors__.append(
+                        ValidationException("mapping with implicit null key")
+                    )
+                elif ":" in k:
+                    ex = expand_url(
+                        k, "", loadingOptions, scoped_id=False, vocab_term=False
+                    )
+                    extension_fields[ex] = _doc[k]
+                else:
+                    _errors__.append(
+                        ValidationException(
+                            "invalid field `{}`, expected one of: `name`, `type`, `format`".format(
+                                k
+                            ),
+                            SourceLine(_doc, k, str),
+                        )
+                    )
+
+        if _errors__:
+            raise ValidationException("", None, _errors__, "*")
+        _constructed = cls(
+            name=name,
+            type_=type_,
+            format=format,
+            extension_fields=extension_fields,
+            loadingOptions=loadingOptions,
+        )
+        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        return _constructed
+
+    def save(
+        self, top: bool = False, base_url: str = "", relative_uris: bool = True
+    ) -> dict[str, Any]:
+        r: dict[str, Any] = {}
+
+        if relative_uris:
+            for ef in self.extension_fields:
+                r[prefix_url(ef, self.loadingOptions.vocab)] = self.extension_fields[ef]
+        else:
+            for ef in self.extension_fields:
+                r[ef] = self.extension_fields[ef]
+        if self.name is not None:
+            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            r["name"] = u
+        if self.type_ is not None:
+            r["type"] = save(
+                self.type_, top=False, base_url=self.name, relative_uris=relative_uris
+            )
+        if self.format is not None:
+            r["format"] = save(
+                self.format, top=False, base_url=self.name, relative_uris=relative_uris
+            )
+
+        # top refers to the directory level
+        if top:
+            if self.loadingOptions.namespaces:
+                r["$namespaces"] = self.loadingOptions.namespaces
+            if self.loadingOptions.schemas:
+                r["$schemas"] = self.loadingOptions.schemas
+        return r
+
+    attrs = frozenset(["name", "type", "format"])
+
+
 class WorkflowTextOption(Saveable):
     """
     A `{value, label}` option used in `restrictions` or `suggestions` on a
@@ -12280,6 +12557,7 @@ _vocab = {
     "Person": "https://galaxyproject.org/gxformat2/native_v0_1#NativeCreatorPersonType/Person",
     "PrimitiveType": "https://w3id.org/cwl/salad#PrimitiveType",
     "RecordField": "https://w3id.org/cwl/salad#RecordField",
+    "RecordFieldDefinition": "https://galaxyproject.org/gxformat2/gxformat2common#RecordFieldDefinition",
     "RecordSchema": "https://w3id.org/cwl/salad#RecordSchema",
     "ReferencesTool": "https://galaxyproject.org/gxformat2/gxformat2common#ReferencesTool",
     "SampleSheetColumnDefinition": "https://galaxyproject.org/gxformat2/gxformat2common#SampleSheetColumnDefinition",
@@ -12342,6 +12620,7 @@ _rvocab = {
     "https://galaxyproject.org/gxformat2/native_v0_1#NativeCreatorPersonType/Person": "Person",
     "https://w3id.org/cwl/salad#PrimitiveType": "PrimitiveType",
     "https://w3id.org/cwl/salad#RecordField": "RecordField",
+    "https://galaxyproject.org/gxformat2/gxformat2common#RecordFieldDefinition": "RecordFieldDefinition",
     "https://w3id.org/cwl/salad#RecordSchema": "RecordSchema",
     "https://galaxyproject.org/gxformat2/gxformat2common#ReferencesTool": "ReferencesTool",
     "https://galaxyproject.org/gxformat2/gxformat2common#SampleSheetColumnDefinition": "SampleSheetColumnDefinition",
@@ -12410,6 +12689,7 @@ StepPositionLoader = _RecordLoader(StepPosition, None, None)
 SampleSheetColumnDefinitionLoader = _RecordLoader(
     SampleSheetColumnDefinition, None, None
 )
+RecordFieldDefinitionLoader = _RecordLoader(RecordFieldDefinition, None, None)
 WorkflowTextOptionLoader = _RecordLoader(WorkflowTextOption, None, None)
 ToolShedRepositoryLoader = _RecordLoader(ToolShedRepository, None, None)
 NativeStepTypeLoader = _EnumLoader(
@@ -12598,6 +12878,15 @@ union_of_None_type_or_array_of_union_of_strtype_or_inttype_or_floattype_or_boolt
             array_of_union_of_strtype_or_inttype_or_floattype_or_booltype,
         )
     )
+)
+union_of_strtype_or_array_of_strtype = _UnionLoader(
+    (
+        strtype,
+        array_of_strtype,
+    )
+)
+typedsl_union_of_strtype_or_array_of_strtype_2 = _TypeDSLLoader(
+    union_of_strtype_or_array_of_strtype, 2, "v1.1"
 )
 typedsl_union_of_None_type_or_strtype_2 = _TypeDSLLoader(
     union_of_None_type_or_strtype, 2, "v1.1"

--- a/gxformat2/schema/v19_09.py
+++ b/gxformat2/schema/v19_09.py
@@ -2894,6 +2894,283 @@ class SampleSheetColumnDefinition(Saveable):
     )
 
 
+class RecordFieldDefinition(Saveable):
+    """
+    Describes one field of a `record` collection input.
+    Used in `fields` on a `collection_type` containing `record` (e.g.
+    `record`, `list:record`, `sample_sheet:record`). Mirrors a subset of
+    the CWL `InputRecordSchema` shape that Galaxy persists on
+    `DatasetCollection.fields`.
+
+    """
+
+    name: str
+
+    def __init__(
+        self,
+        name: Any,
+        type_: Any,
+        format: Optional[Any] = None,
+        extension_fields: Optional[dict[str, Any]] = None,
+        loadingOptions: Optional[LoadingOptions] = None,
+    ) -> None:
+        if extension_fields:
+            self.extension_fields = extension_fields
+        else:
+            self.extension_fields = CommentedMap()
+        if loadingOptions:
+            self.loadingOptions = loadingOptions
+        else:
+            self.loadingOptions = LoadingOptions()
+        self.name = name if name is not None else "_:" + str(_uuid__.uuid4())
+        self.type_ = type_
+        self.format = format
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, RecordFieldDefinition):
+            return bool(
+                self.name == other.name
+                and self.type_ == other.type_
+                and self.format == other.format
+            )
+        return False
+
+    def __hash__(self) -> int:
+        return hash((self.name, self.type_, self.format))
+
+    @classmethod
+    def fromDoc(
+        cls,
+        doc: Any,
+        baseuri: str,
+        loadingOptions: LoadingOptions,
+        docRoot: Optional[str] = None
+    ) -> "RecordFieldDefinition":
+        _doc = copy.copy(doc)
+
+        if hasattr(doc, "lc"):
+            _doc.lc.data = doc.lc.data
+            _doc.lc.filename = doc.lc.filename
+        _errors__ = []
+        name = None
+        if "name" in _doc:
+            try:
+                name = load_field(
+                    _doc.get("name"),
+                    uri_strtype_True_False_None_None,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("name")
+                )
+
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `name`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("name")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `name` field is not valid because:",
+                                SourceLine(_doc, "name", str),
+                                [e],
+                                detailed_message=f"the `name` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+
+        __original_name_is_none = name is None
+        if name is None:
+            if docRoot is not None:
+                name = docRoot
+            else:
+                _errors__.append(ValidationException("missing name"))
+        if not __original_name_is_none:
+            baseuri = cast(str, name)
+        try:
+            if _doc.get("type") is None:
+                raise ValidationException("missing required field `type`", None, [])
+
+            type_ = load_field(
+                _doc.get("type"),
+                typedsl_union_of_strtype_or_array_of_strtype_2,
+                baseuri,
+                loadingOptions,
+                lc=_doc.get("type")
+            )
+
+        except ValidationException as e:
+            error_message, to_print, verb_tensage = parse_errors(str(e))
+
+            if str(e) == "missing required field `type`":
+                _errors__.append(
+                    ValidationException(
+                        str(e),
+                        None
+                    )
+                )
+            else:
+                val = _doc.get("type")
+                if error_message != str(e):
+                    val_type = convert_typing(extract_type(type(val)))
+                    _errors__.append(
+                        ValidationException(
+                            "the `type` field is not valid because:",
+                            SourceLine(_doc, "type", str),
+                            [ValidationException(f"Value is a {val_type}, "
+                                                 f"but valid {to_print} for this field "
+                                                 f"{verb_tensage} {error_message}",
+                                                 detailed_message=f"Value `{val}` is a {val_type}, "
+                                                 f"but valid {to_print} for this field "
+                                                 f"{verb_tensage} {error_message}")],
+                        )
+                    )
+                else:
+                    _errors__.append(
+                        ValidationException(
+                            "the `type` field is not valid because:",
+                            SourceLine(_doc, "type", str),
+                            [e],
+                            detailed_message=f"the `type` field with value `{val}` "
+                            "is not valid because:",
+                        )
+                    )
+        format = None
+        if "format" in _doc:
+            try:
+                format = load_field(
+                    _doc.get("format"),
+                    union_of_None_type_or_strtype,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("format")
+                )
+
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `format`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("format")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `format` field is not valid because:",
+                                SourceLine(_doc, "format", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `format` field is not valid because:",
+                                SourceLine(_doc, "format", str),
+                                [e],
+                                detailed_message=f"the `format` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
+        extension_fields: dict[str, Any] = {}
+        for k in _doc.keys():
+            if k not in cls.attrs:
+                if not k:
+                    _errors__.append(
+                        ValidationException("mapping with implicit null key")
+                    )
+                elif ":" in k:
+                    ex = expand_url(
+                        k, "", loadingOptions, scoped_id=False, vocab_term=False
+                    )
+                    extension_fields[ex] = _doc[k]
+                else:
+                    _errors__.append(
+                        ValidationException(
+                            "invalid field `{}`, expected one of: `name`, `type`, `format`".format(
+                                k
+                            ),
+                            SourceLine(_doc, k, str),
+                        )
+                    )
+
+        if _errors__:
+            raise ValidationException("", None, _errors__, "*")
+        _constructed = cls(
+            name=name,
+            type_=type_,
+            format=format,
+            extension_fields=extension_fields,
+            loadingOptions=loadingOptions,
+        )
+        loadingOptions.idx[cast(str, name)] = (_constructed, loadingOptions)
+        return _constructed
+
+    def save(
+        self, top: bool = False, base_url: str = "", relative_uris: bool = True
+    ) -> dict[str, Any]:
+        r: dict[str, Any] = {}
+
+        if relative_uris:
+            for ef in self.extension_fields:
+                r[prefix_url(ef, self.loadingOptions.vocab)] = self.extension_fields[ef]
+        else:
+            for ef in self.extension_fields:
+                r[ef] = self.extension_fields[ef]
+        if self.name is not None:
+            u = save_relative_uri(self.name, base_url, True, None, relative_uris)
+            r["name"] = u
+        if self.type_ is not None:
+            r["type"] = save(
+                self.type_, top=False, base_url=self.name, relative_uris=relative_uris
+            )
+        if self.format is not None:
+            r["format"] = save(
+                self.format, top=False, base_url=self.name, relative_uris=relative_uris
+            )
+
+        # top refers to the directory level
+        if top:
+            if self.loadingOptions.namespaces:
+                r["$namespaces"] = self.loadingOptions.namespaces
+            if self.loadingOptions.schemas:
+                r["$schemas"] = self.loadingOptions.schemas
+        return r
+
+    attrs = frozenset(["name", "type", "format"])
+
+
 class WorkflowTextOption(Saveable):
     """
     A `{value, label}` option used in `restrictions` or `suggestions` on a
@@ -4947,6 +5224,7 @@ class WorkflowCollectionParameter(BaseDataParameter):
         format: Optional[Any] = None,
         collection_type: Optional[Any] = None,
         column_definitions: Optional[Any] = None,
+        fields: Optional[Any] = None,
         extension_fields: Optional[dict[str, Any]] = None,
         loadingOptions: Optional[LoadingOptions] = None,
     ) -> None:
@@ -4968,6 +5246,7 @@ class WorkflowCollectionParameter(BaseDataParameter):
         self.type_ = type_
         self.collection_type = collection_type
         self.column_definitions = column_definitions
+        self.fields = fields
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, WorkflowCollectionParameter):
@@ -4982,6 +5261,7 @@ class WorkflowCollectionParameter(BaseDataParameter):
                 and self.type_ == other.type_
                 and self.collection_type == other.collection_type
                 and self.column_definitions == other.column_definitions
+                and self.fields == other.fields
             )
         return False
 
@@ -4998,6 +5278,7 @@ class WorkflowCollectionParameter(BaseDataParameter):
                 self.type_,
                 self.collection_type,
                 self.column_definitions,
+                self.fields,
             )
         )
 
@@ -5495,6 +5776,53 @@ class WorkflowCollectionParameter(BaseDataParameter):
                                 "is not valid because:",
                             )
                         )
+        fields = None
+        if "fields" in _doc:
+            try:
+                fields = load_field(
+                    _doc.get("fields"),
+                    idmap_fields_union_of_None_type_or_array_of_RecordFieldDefinitionLoader,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("fields")
+                )
+
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `fields`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("fields")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `fields` field is not valid because:",
+                                SourceLine(_doc, "fields", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `fields` field is not valid because:",
+                                SourceLine(_doc, "fields", str),
+                                [e],
+                                detailed_message=f"the `fields` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
         extension_fields: dict[str, Any] = {}
         for k in _doc.keys():
             if k not in cls.attrs:
@@ -5510,7 +5838,7 @@ class WorkflowCollectionParameter(BaseDataParameter):
                 else:
                     _errors__.append(
                         ValidationException(
-                            "invalid field `{}`, expected one of: `label`, `doc`, `id`, `default`, `position`, `optional`, `format`, `type`, `collection_type`, `column_definitions`".format(
+                            "invalid field `{}`, expected one of: `label`, `doc`, `id`, `default`, `position`, `optional`, `format`, `type`, `collection_type`, `column_definitions`, `fields`".format(
                                 k
                             ),
                             SourceLine(_doc, k, str),
@@ -5530,6 +5858,7 @@ class WorkflowCollectionParameter(BaseDataParameter):
             type_=type_,
             collection_type=collection_type,
             column_definitions=column_definitions,
+            fields=fields,
             extension_fields=extension_fields,
             loadingOptions=loadingOptions,
         )
@@ -5592,6 +5921,10 @@ class WorkflowCollectionParameter(BaseDataParameter):
                 base_url=self.id,
                 relative_uris=relative_uris,
             )
+        if self.fields is not None:
+            r["fields"] = save(
+                self.fields, top=False, base_url=self.id, relative_uris=relative_uris
+            )
 
         # top refers to the directory level
         if top:
@@ -5613,6 +5946,7 @@ class WorkflowCollectionParameter(BaseDataParameter):
             "type",
             "collection_type",
             "column_definitions",
+            "fields",
         ]
     )
 
@@ -8273,6 +8607,7 @@ class WorkflowInputParameter(BaseDataParameter, MinMax):
         format: Optional[Any] = None,
         collection_type: Optional[Any] = None,
         column_definitions: Optional[Any] = None,
+        fields: Optional[Any] = None,
         restrictions: Optional[Any] = None,
         suggestions: Optional[Any] = None,
         restrictOnConnections: Optional[Any] = None,
@@ -8299,6 +8634,7 @@ class WorkflowInputParameter(BaseDataParameter, MinMax):
         self.type_ = type_
         self.collection_type = collection_type
         self.column_definitions = column_definitions
+        self.fields = fields
         self.restrictions = restrictions
         self.suggestions = suggestions
         self.restrictOnConnections = restrictOnConnections
@@ -8318,6 +8654,7 @@ class WorkflowInputParameter(BaseDataParameter, MinMax):
                 and self.type_ == other.type_
                 and self.collection_type == other.collection_type
                 and self.column_definitions == other.column_definitions
+                and self.fields == other.fields
                 and self.restrictions == other.restrictions
                 and self.suggestions == other.suggestions
                 and self.restrictOnConnections == other.restrictOnConnections
@@ -8339,6 +8676,7 @@ class WorkflowInputParameter(BaseDataParameter, MinMax):
                 self.type_,
                 self.collection_type,
                 self.column_definitions,
+                self.fields,
                 self.restrictions,
                 self.suggestions,
                 self.restrictOnConnections,
@@ -8932,6 +9270,53 @@ class WorkflowInputParameter(BaseDataParameter, MinMax):
                                 "is not valid because:",
                             )
                         )
+        fields = None
+        if "fields" in _doc:
+            try:
+                fields = load_field(
+                    _doc.get("fields"),
+                    idmap_fields_union_of_None_type_or_array_of_RecordFieldDefinitionLoader,
+                    baseuri,
+                    loadingOptions,
+                    lc=_doc.get("fields")
+                )
+
+            except ValidationException as e:
+                error_message, to_print, verb_tensage = parse_errors(str(e))
+
+                if str(e) == "missing required field `fields`":
+                    _errors__.append(
+                        ValidationException(
+                            str(e),
+                            None
+                        )
+                    )
+                else:
+                    val = _doc.get("fields")
+                    if error_message != str(e):
+                        val_type = convert_typing(extract_type(type(val)))
+                        _errors__.append(
+                            ValidationException(
+                                "the `fields` field is not valid because:",
+                                SourceLine(_doc, "fields", str),
+                                [ValidationException(f"Value is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}",
+                                                     detailed_message=f"Value `{val}` is a {val_type}, "
+                                                     f"but valid {to_print} for this field "
+                                                     f"{verb_tensage} {error_message}")],
+                            )
+                        )
+                    else:
+                        _errors__.append(
+                            ValidationException(
+                                "the `fields` field is not valid because:",
+                                SourceLine(_doc, "fields", str),
+                                [e],
+                                detailed_message=f"the `fields` field with value `{val}` "
+                                "is not valid because:",
+                            )
+                        )
         restrictions = None
         if "restrictions" in _doc:
             try:
@@ -9088,7 +9473,7 @@ class WorkflowInputParameter(BaseDataParameter, MinMax):
                 else:
                     _errors__.append(
                         ValidationException(
-                            "invalid field `{}`, expected one of: `label`, `doc`, `id`, `default`, `position`, `optional`, `format`, `min`, `max`, `type`, `collection_type`, `column_definitions`, `restrictions`, `suggestions`, `restrictOnConnections`".format(
+                            "invalid field `{}`, expected one of: `label`, `doc`, `id`, `default`, `position`, `optional`, `format`, `min`, `max`, `type`, `collection_type`, `column_definitions`, `fields`, `restrictions`, `suggestions`, `restrictOnConnections`".format(
                                 k
                             ),
                             SourceLine(_doc, k, str),
@@ -9110,6 +9495,7 @@ class WorkflowInputParameter(BaseDataParameter, MinMax):
             type_=type_,
             collection_type=collection_type,
             column_definitions=column_definitions,
+            fields=fields,
             restrictions=restrictions,
             suggestions=suggestions,
             restrictOnConnections=restrictOnConnections,
@@ -9183,6 +9569,10 @@ class WorkflowInputParameter(BaseDataParameter, MinMax):
                 base_url=self.id,
                 relative_uris=relative_uris,
             )
+        if self.fields is not None:
+            r["fields"] = save(
+                self.fields, top=False, base_url=self.id, relative_uris=relative_uris
+            )
         if self.restrictions is not None:
             r["restrictions"] = save(
                 self.restrictions,
@@ -9227,6 +9617,7 @@ class WorkflowInputParameter(BaseDataParameter, MinMax):
             "type",
             "collection_type",
             "column_definitions",
+            "fields",
             "restrictions",
             "suggestions",
             "restrictOnConnections",
@@ -16559,6 +16950,7 @@ _vocab = {
     "PrimitiveType": "https://w3id.org/cwl/salad#PrimitiveType",
     "Process": "https://w3id.org/cwl/cwl#Process",
     "RecordField": "https://w3id.org/cwl/salad#RecordField",
+    "RecordFieldDefinition": "https://galaxyproject.org/gxformat2/gxformat2common#RecordFieldDefinition",
     "RecordSchema": "https://w3id.org/cwl/salad#RecordSchema",
     "ReferencesTool": "https://galaxyproject.org/gxformat2/gxformat2common#ReferencesTool",
     "Report": "https://galaxyproject.org/gxformat2/v19_09#Report",
@@ -16633,6 +17025,7 @@ _rvocab = {
     "https://w3id.org/cwl/salad#PrimitiveType": "PrimitiveType",
     "https://w3id.org/cwl/cwl#Process": "Process",
     "https://w3id.org/cwl/salad#RecordField": "RecordField",
+    "https://galaxyproject.org/gxformat2/gxformat2common#RecordFieldDefinition": "RecordFieldDefinition",
     "https://w3id.org/cwl/salad#RecordSchema": "RecordSchema",
     "https://galaxyproject.org/gxformat2/gxformat2common#ReferencesTool": "ReferencesTool",
     "https://galaxyproject.org/gxformat2/v19_09#Report": "Report",
@@ -16718,6 +17111,7 @@ StepPositionLoader = _RecordLoader(StepPosition, None, None)
 SampleSheetColumnDefinitionLoader = _RecordLoader(
     SampleSheetColumnDefinition, None, None
 )
+RecordFieldDefinitionLoader = _RecordLoader(RecordFieldDefinition, None, None)
 WorkflowTextOptionLoader = _RecordLoader(WorkflowTextOption, None, None)
 ToolShedRepositoryLoader = _RecordLoader(ToolShedRepository, None, None)
 GalaxyTypeLoader = _EnumLoader(
@@ -16958,6 +17352,15 @@ union_of_None_type_or_array_of_union_of_strtype_or_inttype_or_floattype_or_boolt
         )
     )
 )
+union_of_strtype_or_array_of_strtype = _UnionLoader(
+    (
+        strtype,
+        array_of_strtype,
+    )
+)
+typedsl_union_of_strtype_or_array_of_strtype_2 = _TypeDSLLoader(
+    union_of_strtype_or_array_of_strtype, 2, "v1.1"
+)
 union_of_booltype_or_None_type = _UnionLoader(
     (
         booltype,
@@ -16987,6 +17390,16 @@ union_of_None_type_or_array_of_SampleSheetColumnDefinitionLoader = _UnionLoader(
         None_type,
         array_of_SampleSheetColumnDefinitionLoader,
     )
+)
+array_of_RecordFieldDefinitionLoader = _ArrayLoader(RecordFieldDefinitionLoader)
+union_of_None_type_or_array_of_RecordFieldDefinitionLoader = _UnionLoader(
+    (
+        None_type,
+        array_of_RecordFieldDefinitionLoader,
+    )
+)
+idmap_fields_union_of_None_type_or_array_of_RecordFieldDefinitionLoader = _IdMapLoader(
+    union_of_None_type_or_array_of_RecordFieldDefinitionLoader, "name", "type"
 )
 union_of_inttype_or_floattype_or_None_type = _UnionLoader(
     (

--- a/schema/common/common.yml
+++ b/schema/common/common.yml
@@ -152,6 +152,42 @@ $graph:
       doc: |
         Open suggestion list for this column.
 
+- name: RecordFieldDefinition
+  type: record
+  doc: |
+    Describes one field of a `record` collection input.
+    Used in `fields` on a `collection_type` containing `record` (e.g.
+    `record`, `list:record`, `sample_sheet:record`). Mirrors a subset of
+    the CWL `InputRecordSchema` shape that Galaxy persists on
+    `DatasetCollection.fields`.
+  fields:
+    - name: name
+      type: string
+      jsonldPredicate: "@id"
+      doc: |
+        Field name. Must equal the corresponding element identifier in
+        the materialized record collection.
+    - name: type
+      type:
+        - string
+        - type: array
+          items: string
+      pydantic:type: 'Literal["File", "null", "boolean", "int", "float", "string"] | list[Literal["File", "null", "boolean", "int", "float", "string"]]'
+      jsonldPredicate:
+        "_id": "sld:type"
+        "_type": "@vocab"
+        refScope: 2
+        typeDSL: True
+      doc: |
+        Field value type. A subset of the CWL primitive types: `File`,
+        `null`, `boolean`, `int`, `float`, `string`. May be a list to
+        express a union (e.g. `["File", "null"]` for an optional file).
+    - name: format
+      type: string?
+      jsonldPredicate: "https://galaxyproject.org/gxformat2/v19_09#BaseDataParameter/format"
+      doc: |
+        Optional Galaxy datatype hint for `File`-typed fields.
+
 - name: WorkflowTextOption
   type: record
   doc: |

--- a/schema/v19_09/workflow.yml
+++ b/schema/v19_09/workflow.yml
@@ -159,6 +159,19 @@ $graph:
         - type: array
           items: gxformat2common:SampleSheetColumnDefinition
       jsonldPredicate: "gxformat2:column_definitions"
+    - name: fields
+      doc: |
+        Field schema for `record` collection inputs. Only meaningful when
+        `collection_type` contains `record` (e.g. `record`, `list:record`,
+        `sample_sheet:record`).
+      type:
+        - "null"
+        - type: array
+          items: gxformat2common:RecordFieldDefinition
+      jsonldPredicate:
+        _id: "sld:fields"
+        mapSubject: name
+        mapPredicate: type
 
 - name: MinMax
   type: record
@@ -341,6 +354,18 @@ $graph:
         - type: array
           items: gxformat2common:SampleSheetColumnDefinition
       jsonldPredicate: "gxformat2:column_definitions"
+    - name: fields
+      doc: |
+        Field schema for `record` collection inputs. Only meaningful when
+        `collection_type` contains `record`.
+      type:
+        - "null"
+        - type: array
+          items: gxformat2common:RecordFieldDefinition
+      jsonldPredicate:
+        _id: "sld:fields"
+        mapSubject: name
+        mapPredicate: type
     - name: restrictions
       type:
         - "null"

--- a/tests/example_wfs.py
+++ b/tests/example_wfs.py
@@ -24,6 +24,7 @@ SLASH_IN_INPUT_LABEL = load_contents("synthetic-slash-in-input-label.gxwf.yml")
 SLASH_IN_STEP_LABEL_EXPLICIT_OUTPUT = load_contents("synthetic-slash-in-step-label.gxwf.yml")
 SLASH_IN_LABEL_CHAINED = load_contents("synthetic-slash-in-label-chained.gxwf.yml")
 SAMPLE_SHEET_COLLECTION_INPUT = load_contents("synthetic-sample-sheet-input.gxwf.yml")
+RECORD_COLLECTION_INPUT = load_contents("synthetic-record-input.gxwf.yml")
 WORKFLOW_WITH_COMMENTS_DICT = load_contents("synthetic-comments-dict.gxwf.yml")
 USER_DEFINED_TOOL_WORKFLOW = load_contents("synthetic-user-defined-tool.gxwf.yml")
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -14,6 +14,7 @@ from ._helpers import (
 from .example_wfs import (
     OPTIONAL_INPUT,
     PAIRED_LIST_COLLECTION_INPUT,
+    RECORD_COLLECTION_INPUT,
     SAMPLE_SHEET_COLLECTION_INPUT,
     SLASH_IN_INPUT_LABEL,
     SLASH_IN_LABEL_CHAINED,
@@ -395,6 +396,18 @@ def test_optional_inputs():
 def test_paired_list_inputs():
     as_dict = round_trip(PAIRED_LIST_COLLECTION_INPUT)
     assert as_dict["inputs"]["input_list"]["collection_type"] == "list:paired"
+
+
+def test_record_inputs():
+    as_dict = round_trip(RECORD_COLLECTION_INPUT)
+    assert as_dict["inputs"]["input_record"]["collection_type"] == "record"
+    fields = as_dict["inputs"]["input_record"]["fields"]
+    assert fields
+    assert len(fields) == 2
+    assert fields[0]["name"] == "parent"
+    assert fields[0]["type"] == "File"
+    assert fields[1]["name"] == "child"
+    assert fields[1]["type"] == ["File", "null"]
 
 
 def test_sample_sheet_inputs():


### PR DESCRIPTION
## Summary
- Adds `RecordFieldDefinition` (name/type/format) to `schema/common/common.yml` and a `fields` field on both `WorkflowInputParameter` forms in `schema/v19_09/workflow.yml`. Regenerates `gxformat2/schema/*.py`.
- Simplifies `_build_input_step` in `gxformat2/normalized/_conversion.py` — drops the `model_extra` fallback for `fields` now that it's typed.
- Semantic validator (`gxformat2/_semantic_validators.py`) rejects `fields` unless `collection_type` contains `record` (e.g. `record`, `list:record`, `sample_sheet:record`).
- New fixtures `synthetic-record-input.gxwf.yml` (valid) and `synthetic-bad-fields-on-list.gxwf.yml` (negative).
- Declarative expectations for normalize / to_native / validate lax+strict, plus a `test_record_inputs` round-trip in `tests/test_basic.py`.

Follow-up to the unmodelled-field thread on #212; closes #214.

## Test plan
- [x] `uv run --group test pytest tests/ -x -q` — 689 passed
- [x] `uv run --group lint ruff check` / `black --check` / `mypy gxformat2` clean
- [x] `bash build_schema.sh` produces no diff in `gxformat2/schema/*.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)