### PR TITLE
Enforce state / tool_state mutual exclusion on workflow steps

### DIFF
--- a/gxformat2/_semantic_validators.py
+++ b/gxformat2/_semantic_validators.py
@@ -126,6 +126,35 @@ def validate_input_parameter(input_param: Any) -> None:
             raise ValueError(f"{field} is only valid on text/string inputs, got type={type_value!r}")
 
 
+def _state_is_specified(value: Any) -> bool:
+    """True when a step's ``state``/``tool_state`` field actually carries content.
+
+    Uses non-empty semantics: ``None``, an empty dict, and a blank or ``{}``
+    JSON string all count as unspecified. This matches the downstream notion of
+    an "empty" state, so an empty ``state: {}`` left by conversion does not
+    falsely conflict with a populated ``tool_state``.
+    """
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return value.strip() not in ("", "{}")
+    if isinstance(value, Mapping):
+        return len(value) > 0
+    return bool(value)
+
+
+def validate_step(step: Mapping[str, Any]) -> None:
+    """Validate cross-field rules on a single workflow step.
+
+    Enforces:
+    - ``state`` and ``tool_state`` are mutually exclusive (the schema doc says
+      "Only one or the other should be specified"); they are two encodings of
+      the same tool state, so carrying both is ambiguous.
+    """
+    if _state_is_specified(step.get("state")) and _state_is_specified(step.get("tool_state")):
+        raise ValueError("Workflow step specifies both 'state' and 'tool_state'; only one may be set")
+
+
 def validate_workflow(workflow: Any) -> None:
     """Walk a (lax or strict) GalaxyWorkflow model and validate cross-field rules.
 
@@ -153,6 +182,7 @@ def validate_workflow(workflow: Any) -> None:
     for step in iter_steps:
         if not isinstance(step, Mapping):
             continue
+        validate_step(step)
         run = step.get("run")
         if isinstance(run, Mapping) and run.get("class") == "GalaxyWorkflow":
             validate_workflow(run)

--- a/gxformat2/_semantic_validators.py
+++ b/gxformat2/_semantic_validators.py
@@ -127,7 +127,7 @@ def validate_input_parameter(input_param: Any) -> None:
 
 
 def _state_is_specified(value: Any) -> bool:
-    """True when a step's ``state``/``tool_state`` field actually carries content.
+    """Report whether a step's ``state``/``tool_state`` field actually carries content.
 
     Uses non-empty semantics: ``None``, an empty dict, and a blank or ``{}``
     JSON string all count as unspecified. This matches the downstream notion of

--- a/gxformat2/_semantic_validators.py
+++ b/gxformat2/_semantic_validators.py
@@ -156,7 +156,7 @@ def validate_step(step: Mapping[str, Any]) -> None:
 
 
 def validate_workflow(workflow: Any) -> None:
-    """Walk a (lax or strict) GalaxyWorkflow model and validate cross-field rules.
+    """Validate cross-field rules on a (lax or strict) GalaxyWorkflow model.
 
     Handles both list and dict input forms.
     """

--- a/gxformat2/examples/catalog.yml
+++ b/gxformat2/examples/catalog.yml
@@ -303,6 +303,12 @@
   tests:
     - tests/test_interop_tests.py
 
+- file: format2/synthetic-state-tool-state-conflict.gxwf.yml
+  origin: synthetic
+  format: format2
+  tests:
+    - tests/test_interop_tests.py
+
 - file: format2/synthetic-tags.gxwf.yml
   origin: synthetic
   format: format2

--- a/gxformat2/examples/expectations/validate_format2.yml
+++ b/gxformat2/examples/expectations/validate_format2.yml
@@ -402,3 +402,15 @@ test_report_bad_type_rejected_format2_strict:
   fixture: synthetic-lint-report-bad-type.gxwf.yml
   operation: validate_format2_strict
   expect_error: true
+
+# --- state / tool_state are mutually exclusive ---
+
+test_state_tool_state_conflict_rejected_format2:
+  fixture: synthetic-state-tool-state-conflict.gxwf.yml
+  operation: validate_format2
+  expect_error: true
+
+test_state_tool_state_conflict_rejected_format2_strict:
+  fixture: synthetic-state-tool-state-conflict.gxwf.yml
+  operation: validate_format2_strict
+  expect_error: true

--- a/gxformat2/examples/format2/synthetic-state-tool-state-conflict.gxwf.yml
+++ b/gxformat2/examples/format2/synthetic-state-tool-state-conflict.gxwf.yml
@@ -1,0 +1,12 @@
+class: GalaxyWorkflow
+inputs:
+  x: data
+outputs: {}
+steps:
+  step1:
+    tool_id: cat1
+    state:
+      num_lines: 5
+    tool_state: '{"input1": "value1", "num_lines": 5}'
+    in:
+      input1: x


### PR DESCRIPTION
> 🤖 Opened by Claude (AI assistant) on @jmchilton's behalf, not authored by them personally.

## What

A Format2 workflow step's `state` and `tool_state` are two encodings of the same tool state. The schema docstring has long said:

> Only one or the other should be specified.

…but nothing enforced it. `validate_format2` (and `validate_format2_strict`) now raise when a step carries both.

## Details

- Check lives in `_semantic_validators.py` alongside the existing cross-field rules, wired into the `validate_workflow` step walk (so it covers inline subworkflows via the existing recursion).
- **Non-empty semantics**: `None`, an empty dict, and a blank or `{}` JSON string all count as *unspecified*. This matters because conversion can legitimately leave an empty `state: {}` on a step — that must not falsely conflict with a populated `tool_state`.

## Tests

- New synthetic fixture `synthetic-state-tool-state-conflict.gxwf.yml` (a step with both fields).
- Declarative expectations in `validate_format2.yml`: `test_state_tool_state_conflict_rejected_format2` + `_strict`, both `expect_error: true`.
- Catalog entry added.
- Full suite green (`707 passed, 8 skipped`); ruff / flake8 / black / mypy clean.

## Downstream

Mirrors a matching check in the TypeScript port (galaxy-tool-util-ts), which consumes these declarative fixtures/expectations via sync — this lands the shared red-to-green tests upstream first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)