### PR TITLE
Harden GitHub Actions workflows (zizmor)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,5 +10,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
     cooldown:
       default-days: 7

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,13 +1,14 @@
 name: Deploy
 on: [push, pull_request]
+permissions: {}
 jobs:
   build_packages:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.14'
           cache: pip
@@ -16,7 +17,7 @@ jobs:
           python3 -m pip install build twine
       - name: Create and check sdist and wheel packages
         run: make dist
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: packages
           path: dist/
@@ -28,9 +29,9 @@ jobs:
       id-token: write
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && github.repository_owner == 'galaxyproject'
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: packages
           path: dist
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -5,10 +5,10 @@ jobs:
   build_packages:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.14'
           cache: pip
@@ -17,7 +17,7 @@ jobs:
           python3 -m pip install build twine
       - name: Create and check sdist and wheel packages
         run: make dist
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      - uses: actions/upload-artifact@v7
         with:
           name: packages
           path: dist/
@@ -29,9 +29,9 @@ jobs:
       id-token: write
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && github.repository_owner == 'galaxyproject'
     steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      - uses: actions/download-artifact@v8
         with:
           name: packages
           path: dist
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,15 +1,16 @@
 name: Java CI
 on: [push, pull_request]
+permissions: {}
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: '3.10'
         cache: pip
@@ -21,7 +22,7 @@ jobs:
       run: |
         pytest tests/test_lint.py tests/test_cytoscape.py
     - name: Set up JDK
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
       with:
         distribution: 'temurin'
         java-version: '25'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,11 +6,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+    - uses: actions/checkout@v6
       with:
         persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
         cache: pip
@@ -22,7 +22,7 @@ jobs:
       run: |
         pytest tests/test_lint.py tests/test_cytoscape.py
     - name: Set up JDK
-      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+      uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
         java-version: '25'

--- a/.github/workflows/publishdocs.yml
+++ b/.github/workflows/publishdocs.yml
@@ -5,16 +5,14 @@ concurrency:
   cancel-in-progress: true
 permissions: {}
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+    - uses: actions/checkout@v6
       with:
         persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      uses: actions/setup-python@v6
       with:
         python-version: '3.13'
         cache: pip
@@ -25,9 +23,25 @@ jobs:
     - name: Build docs
       run: |
         USE_VENV=0 SKIP_JAVA=1 SKIP_TYPESCRIPT=1 bash build_schema.sh
+    - uses: actions/upload-artifact@v7
+      with:
+        name: schema
+        path: dist/schema
+  deploy:
+    needs: [build]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'galaxyproject'
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
+    - uses: actions/download-artifact@v8
+      with:
+        name: schema
+        path: dist/schema
     - name: Deploy Docs
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'galaxyproject'
-      uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
+      uses: JamesIves/github-pages-deploy-action@releases/v4
       with:
         folder: dist/schema
-

--- a/.github/workflows/publishdocs.yml
+++ b/.github/workflows/publishdocs.yml
@@ -3,15 +3,18 @@ on: [push, pull_request]
 concurrency:
   group: docs-${{ github.ref }}
   cancel-in-progress: true
+permissions: {}
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: '3.13'
         cache: pip
@@ -24,7 +27,7 @@ jobs:
         USE_VENV=0 SKIP_JAVA=1 SKIP_TYPESCRIPT=1 bash build_schema.sh
     - name: Deploy Docs
       if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'galaxyproject'
-      uses: JamesIves/github-pages-deploy-action@releases/v4
+      uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
       with:
         folder: dist/schema
 

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -14,19 +14,19 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+    - uses: actions/checkout@v6
       with:
         persist-credentials: false
     - name: Clone IWC
       if: matrix.python-version == '3.13'
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      uses: actions/checkout@v6
       with:
         repository: galaxyproject/iwc
         ref: main
         path: iwc
         persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 concurrency:
   group: tox-${{ github.ref }}
   cancel-in-progress: true
+permissions: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,19 +14,19 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         persist-credentials: false
     - name: Clone IWC
       if: matrix.python-version == '3.13'
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         repository: galaxyproject/iwc
         ref: main
         path: iwc
         persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true

--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -6,6 +6,8 @@ concurrency:
   group: build-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
 
   CI:
@@ -14,10 +16,10 @@ jobs:
       run:
         working-directory: ./typescript
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -27,7 +29,7 @@ jobs:
       - run: npm test
       - name: Upload coverage to Codecov
         if: github.repository_owner == 'galaxyproject'
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           directory: ./typescript
           fail_ci_if_error: true

--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -16,10 +16,10 @@ jobs:
       run:
         working-directory: ./typescript
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -29,7 +29,7 @@ jobs:
       - run: npm test
       - name: Upload coverage to Codecov
         if: github.repository_owner == 'galaxyproject'
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
+        uses: codecov/codecov-action@v6
         with:
           directory: ./typescript
           fail_ci_if_error: true

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,9 +1,13 @@
 name: GitHub Actions Security Analysis (zizmor)
 on:
   push:
-    branches: ["main"]
+    paths:
+      - '.github/workflows/*'
+      - zizmor.yml
   pull_request:
-    branches: ["**"]
+    paths:
+      - '.github/workflows/*'
+      - zizmor.yml
 permissions: {}
 jobs:
   zizmor:
@@ -12,7 +16,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+      - uses: zizmorcore/zizmor-action@v0.5.6

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,18 @@
+name: GitHub Actions Security Analysis (zizmor)
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+permissions: {}
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        '*': ref-pin


### PR DESCRIPTION
> [!NOTE]
> Opened by Claude (AI assistant) on behalf of @jmchilton — not authored by them personally.

Brings the workflows to a clean [zizmor](https://docs.zizmor.sh/) bill of health and wires zizmor into CI so it stays that way. `uvx zizmor .` → **no findings**.

## Changes
1. **`zizmor.yml` config** — adopts the same `unpinned-uses: ref-pin` policy as [galaxyproject/galaxy's zizmor.yml](https://github.com/galaxyproject/galaxy/blob/dev/zizmor.yml), so actions are accepted when pinned to a version tag (no commit-hash requirement).
2. **Least-privilege tokens** — top-level `permissions: {}` on every workflow, widened per-job only where needed. `publishdocs` is split into a `build` job (no write scope) that uploads the `dist/schema` artifact and a `deploy` job that downloads it and pushes to gh-pages with `contents: write`, so the write token is isolated from the build. `deploy.yaml`'s pypi job already declared `id-token: write`.
3. **Dependabot** — github-actions updater with weekly schedule, grouped into a single PR, plus a 7-day cooldown.
4. **zizmor in CI** — new `.github/workflows/zizmor.yml` (`zizmorcore/zizmor-action`) triggered on changes to workflow files or `zizmor.yml`, so workflow edits stay linted.

Modeled on galaxyproject/galaxy#22827. Second commit addresses @nsoranzo's review (ref-pin over hashes, isolated docs-deploy write scope, grouped Dependabot updates, path-scoped zizmor triggers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)